### PR TITLE
Prefix support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM swift:6.0-noble
+
+# Install OS updates
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+    && apt-get -q update \
+    && apt-get install -y libssl-dev curl \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+    "name": "Swift",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "false",
+            "username": "vscode",
+            "upgradePackages": "false"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "os-provided",
+            "ppa": "false"
+        }
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "lldb.library": "/usr/lib/liblldb.so"
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "swiftlang.swift-vscode",
+                "EditorConfig.EditorConfig"
+            ]
+        }
+    },
+    "remoteUser": "vscode"
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "9735eff57bb6356b8de611678af39e94d7b98c3aff0c8cc101cbb3dd3f5b2d38",
+  "originHash" : "bb59d80664f242138cd70b5d800f27d88cc1508924f184fe387d5a55b330cb9b",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "60fa3dcfc52d09ed0411e9c4bc99928bf63656bd",
-        "version" : "1.24.2"
+        "revision" : "3b265e6a00fc5c3fdb8f91f773e506990c704337",
+        "version" : "1.26.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/hummingbird.git",
       "state" : {
-        "revision" : "c1d175755fc4eaba84908d769fb83b6f94934691",
-        "version" : "2.8.0"
+        "revision" : "de2ff8249862791a8972842fd13bff014e71a329",
+        "version" : "2.14.0"
       }
     },
     {
@@ -24,8 +24,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-algorithms.git",
       "state" : {
-        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
-        "version" : "1.2.0"
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a54383ada6cecde007d374f58f864e29370ba5c3",
+        "version" : "1.3.2"
       }
     },
     {
@@ -33,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "4c3ea81f81f0a25d0470188459c6d4bf20cf2f97",
-        "version" : "1.0.3"
+        "revision" : "042e1c4d9d19748c9c228f8d4ebc97bb1e339b0b",
+        "version" : "1.0.4"
       }
     },
     {
@@ -47,12 +56,30 @@
       }
     },
     {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "999fd70c7803da89f3904d635a6815a2a7cd7585",
+        "version" : "1.10.0"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
         "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "e8d6eba1fef23ae5b359c46b03f7d94be2f41fed",
+        "version" : "3.12.3"
       }
     },
     {
@@ -65,12 +92,21 @@
       }
     },
     {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "db6eea3692638a65e2124990155cd220c2915903",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "swift-http-types",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types.git",
       "state" : {
-        "revision" : "ef18d829e8b92d731ad27bb81583edd2094d1ce3",
-        "version" : "1.3.1"
+        "revision" : "a0a57e949a8903563aba4615869310c0ebf14c03",
+        "version" : "1.4.0"
       }
     },
     {
@@ -78,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
-        "version" : "1.6.2"
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
       }
     },
     {
@@ -87,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "5e63558d12e0267782019f5dadfcae83a7d06e09",
-        "version" : "2.5.1"
+        "revision" : "4c83e1cdf4ba538ef6e43a9bbd0bcc33a0ca46e3",
+        "version" : "2.7.0"
       }
     },
     {
@@ -96,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "dff45738d84a53dbc8ee899c306b3a7227f54f89",
-        "version" : "2.80.0"
+        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
+        "version" : "2.83.0"
       }
     },
     {
@@ -105,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "2e9746cfc57554f70b650b021b6ae4738abef3e6",
-        "version" : "1.24.1"
+        "revision" : "949cf2d3c895e3a576b0f5c5f902848ba17acbb9",
+        "version" : "1.27.0"
       }
     },
     {
@@ -114,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "170f4ca06b6a9c57b811293cebcb96e81b661310",
-        "version" : "1.35.0"
+        "revision" : "4281466512f63d1bd530e33f4aa6993ee7864be0",
+        "version" : "1.36.0"
       }
     },
     {
@@ -123,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "0cc3528ff48129d64ab9cab0b1cd621634edfc6b",
-        "version" : "2.29.3"
+        "revision" : "4b38f35946d00d8f6176fe58f96d83aba64b36c7",
+        "version" : "2.31.0"
       }
     },
     {
@@ -132,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "3c394067c08d1225ba8442e9cffb520ded417b64",
-        "version" : "1.23.1"
+        "revision" : "cd1e89816d345d2523b11c55654570acd5cd4c56",
+        "version" : "1.24.0"
       }
     },
     {
@@ -141,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics.git",
       "state" : {
-        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
-        "version" : "1.0.2"
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
       }
     },
     {
@@ -159,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
       "state" : {
-        "revision" : "c2e97cf6f81510f2d6b4a69453861db65d478560",
-        "version" : "2.6.3"
+        "revision" : "e7187309187695115033536e8fc9b2eb87fd956d",
+        "version" : "2.8.0"
       }
     },
     {
@@ -177,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
-        "version" : "1.4.0"
+        "revision" : "a34201439c74b53f0fd71ef11741af7e7caf01e1",
+        "version" : "1.4.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -28,9 +28,18 @@ let package = Package(
             dependencies: [
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
             ],
             path: "Sources/RoutingMacros"
         ),
+        .testTarget(
+            name: "HummingbirdMacroRoutingTests",
+            dependencies: [
+                .byName(name: "HummingbirdMacroRouting"),
+                .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "HummingbirdTesting", package: "hummingbird")
+            ],
+            path: "Tests"
+        )
     ]
 )

--- a/Sources/HummingbirdMacroRouting/attachment.swift
+++ b/Sources/HummingbirdMacroRouting/attachment.swift
@@ -1,5 +1,5 @@
 @attached(extension, names: arbitrary)
-public macro MacroRouting() = #externalMacro(module: "RoutingMacros", type: "RoutingMacro")
+public macro MacroRouting(prefix: String? = nil) = #externalMacro(module: "RoutingMacros", type: "RoutingMacro")
 
 @attached(peer, names: arbitrary)
 public macro GET(_ path: String) = #externalMacro(module: "RoutingMacros", type: "GETMacro")

--- a/Tests/HummingbirdMacroRoutingTests.swift
+++ b/Tests/HummingbirdMacroRoutingTests.swift
@@ -1,0 +1,57 @@
+import Testing
+import Hummingbird
+import HummingbirdMacroRouting
+import HummingbirdTesting
+
+@Suite("Simple Macro Routing Tests")
+struct SimpleMacroRoutingTests {
+    typealias Context = SimpleMacroRoutingRequestContext
+    typealias Controller = SimpleMacroRoutingController
+
+    @Test("Static Structure")
+    func testStructureStatic() {
+        #expect(Controller.$Routing.logIn.method == .get)
+        #expect(Controller.$Routing.logIn.path == "/login")
+
+        #expect(Controller.$Routing.logOutHandler.method == .post)
+        #expect(Controller.$Routing.logOutHandler.path == "/logout")
+    }
+
+    @Test("Instance Structure")
+    func testInSitu() async throws {
+        let controller = Controller()
+
+        #expect(type(of: controller.$routes) == RouteCollectionContainer<Context>.self)
+
+        let router = Router(context: Context.self)
+        router.addRoutes(controller.$routes)
+        let app = Application(
+            router: router,
+            configuration: .init()
+        )
+
+        try await app.test(.router) { client in
+            try await client.execute(
+                uri: Controller.$Routing.logIn.path,
+                method: .get
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body) == "Logged in")
+            }
+            try await client.execute(
+                uri: Controller.$Routing.logOutHandler.path,
+                method: .get
+            ) { response in
+                #expect(response.status == .notFound)
+            }
+            try await client.execute(
+                uri: Controller.$Routing.logOutHandler.path,
+                method: .post
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body) == "Logged out")
+            }
+        }
+    }
+
+}

--- a/Tests/Sources/PrefixedMacroRoutingController.swift
+++ b/Tests/Sources/PrefixedMacroRoutingController.swift
@@ -1,0 +1,22 @@
+import Hummingbird
+import HummingbirdMacroRouting
+
+@MacroRouting(prefix: "/api")
+struct PrefixedMacroRoutingController {
+    typealias Context = SimpleMacroRoutingRequestContext
+
+    @GET("/auth")
+    @Sendable func auth(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "Authed")))
+    }
+
+    @GET("/deauth")
+    @Sendable func deauth(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "Deauthed")))
+    }
+
+    @GET("/deauth/:id")
+    @Sendable func deauthId(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "Deauthed")))
+    }
+}

--- a/Tests/Sources/SimpleMacroRoutingController.swift
+++ b/Tests/Sources/SimpleMacroRoutingController.swift
@@ -1,0 +1,17 @@
+import Hummingbird
+import HummingbirdMacroRouting
+
+@MacroRouting
+struct SimpleMacroRoutingController {
+    typealias Context = SimpleMacroRoutingRequestContext
+
+    @GET("/login")
+    @Sendable func logIn(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "Logged in")))
+    }
+
+    @POST("/logout")
+    @Sendable func logOutHandler(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "Logged out")))
+    }
+}

--- a/Tests/Sources/SimpleMacroRoutingRequestContext.swift
+++ b/Tests/Sources/SimpleMacroRoutingRequestContext.swift
@@ -1,0 +1,9 @@
+import Hummingbird
+
+struct SimpleMacroRoutingRequestContext: RequestContext {
+    var coreContext: CoreRequestContextStorage
+
+    init(source: Source) {
+        self.coreContext = .init(source: source)
+    }
+}

--- a/Tests/TestPrefix.swift
+++ b/Tests/TestPrefix.swift
@@ -1,0 +1,49 @@
+import Testing
+import Hummingbird
+import HummingbirdMacroRouting
+import HummingbirdTesting
+
+@Suite("Prefixed Macro Routing Tests")
+struct MacroRoutingTestPrefix {
+    typealias Context = SimpleMacroRoutingRequestContext
+    typealias Controller = PrefixedMacroRoutingController
+
+    @Test("Static Structure")
+    func testStructureStatic() {
+        #expect(Controller.$Routing.prefix == "/api")
+
+        #expect(Controller.$Routing.auth.method == .get)
+        #expect(Controller.$Routing.auth.path == "/api/auth")
+        #expect(Controller.$Routing.deauth.path == "/api/deauth")
+        #expect(Controller.$Routing.auth.rawPath == "/auth")
+        #expect(Controller.$Routing.deauth.rawPath == "/deauth")
+    }
+
+    @Test("Instance Structure")
+    func testInSitu() async throws {
+        let controller = Controller()
+        let router = Router(context: Context.self)
+        router.addRoutes(controller.$routes)
+        let app = Application(
+            router: router,
+            configuration: .init()
+        )
+
+        try await app.test(.router) { client in
+            try await client.execute(
+                uri: "/api/auth",
+                method: .get
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body) == "Authed")
+            }
+            try await client.execute(
+                uri: "/api/deauth",
+                method: .get
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body) == "Deauthed")
+            }
+        }
+    }
+}

--- a/Tests/TestSimple.swift
+++ b/Tests/TestSimple.swift
@@ -4,7 +4,7 @@ import HummingbirdMacroRouting
 import HummingbirdTesting
 
 @Suite("Simple Macro Routing Tests")
-struct SimpleMacroRoutingTests {
+struct MacroRoutingTestSimple {
     typealias Context = SimpleMacroRoutingRequestContext
     typealias Controller = SimpleMacroRoutingController
 
@@ -15,6 +15,8 @@ struct SimpleMacroRoutingTests {
 
         #expect(Controller.$Routing.logOutHandler.method == .post)
         #expect(Controller.$Routing.logOutHandler.path == "/logout")
+
+        #expect(Controller.$Routing.prefix == nil)
     }
 
     @Test("Instance Structure")


### PR DESCRIPTION
Can now do:

```swift
@MacroRouting(prefix: "/api")
```

…and that `prefix` will be added to macro route declarations. `.rawPath` is available for prefix-free inspection in `$Routes`