### PR TITLE
typed parameters for path(…)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,14 @@ let package = Package(
     products: [
         .library(name: "HummingbirdMacroRouting", targets: ["HummingbirdMacroRouting"]),
     ],
+    // Opt-in traits that progressively restrict which spellings of the path-parameter macro are
+    // available, for consumers that need to avoid a name collision. All names are on by default.
+    //   LongParamNamesOnly   – disables #p and #param (leaves #hbParam, #HummingbirdMacroRoutingParam)
+    //   ExplicitParamNameOnly – leaves only #HummingbirdMacroRoutingParam
+    traits: [
+        "LongParamNamesOnly",
+        "ExplicitParamNameOnly",
+    ],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.1"),

--- a/README.md
+++ b/README.md
@@ -198,16 +198,16 @@ The argument names are synthesized by MacroRouting, so they're available to well
 
 #### Typed path parameters
 
-By default, every synthesized `path(…)` argument is a `String`. You can give individual parameters a real Swift type with the `conform:` argument, keyed by parameter name. 
+By default, every synthesized `path(…)` argument is a `String`. You can give an individual parameter a real Swift type with `#p`, right where the parameter appears in the path:
 
 ```swift
-    @GET("/users/{id}", conform: ["id": UUID.self])
+    @GET("/users/\(#p("id", UUID.self))")
     @Sendable func user(request: Request, context: Context) async throws -> Response {
         …
     }
 ```
 
-`ApiController.$Routing.user.path(id:)` now takes a `UUID`, so you can pass the value directly instead of stringifying at the call site:
+`#p("id", UUID.self)` expands to the Hummingbird placeholder `{id}` (so Hummingbird sees the ordinary path `/users/{id}`), while telling MacroRouting that `id` is a `UUID`. `ApiController.$Routing.user.path(id:)` now takes a `UUID`, so you can pass the value directly instead of stringifying at the call site:
 
 ```swift
 let path = ApiController.$Routing.user.path(id: someUuid) // -> "/users/00000000-0000-0000-0000-000000000000"
@@ -215,14 +215,14 @@ let path = ApiController.$Routing.user.path(id: someUuid) // -> "/users/00000000
 
 The value's string-interpolation form (its `description`) is used to build the path—for `UUID` that is identical to `.uuidString`. This is the outbound mirror of Hummingbird's inbound `context.parameters.get(_:as:)`.
 
-Only the parameters you name in `conform:` get a custom type; the rest stay `String`.
+You can mix typed `#p` slots with ordinary `{…}`/`:…` placeholders, which stay `String`:
 
 ```swift
-    @GET("/orgs/{orgId}/users/{userId}/tag/{tag}", conform: ["orgId": UUID.self, "userId": Int.self])
+    @GET("/orgs/\(#p("orgId", UUID.self))/users/\(#p("userId", Int.self))/tag/{tag}")
     // -> path(orgId: UUID, userId: Int, tag: String)
 ```
 
-Any type works, so long as it conforms to `CustomStringConvertible`, *including your own project's types*—just conform them and pass them in `conform:`:
+Any type works, so long as it conforms to `CustomStringConvertible`, *including your own project's types*—just conform them and pass them to `#p`:
 
 ```swift
 struct Slug: CustomStringConvertible {
@@ -231,11 +231,42 @@ struct Slug: CustomStringConvertible {
 }
 
 // …
-    @GET("/post/{slug}", conform: ["slug": Slug.self])
+    @GET("/post/\(#p("slug", Slug.self))")
     // -> path(slug: Slug)
 ```
 
 > **Important:** This does *not* affect how Hummingbird interprets a route/path, but it *does* provide a type-safe way to specify a route with `$Routing.pathHandler.path(…)`.
+
+##### The parameter macro's names, and avoiding collisions
+
+`#p` is short and reads well, but `p` is a common identifier. Because the macro is a *freestanding* macro, it lives in your namespace once you `import HummingbirdMacroRouting`, and Swift offers no way to rename a macro at the import site. To avoid a clash, MacroRouting provides the **same** macro under four spellings—use whichever is free in your project:
+
+| Spelling | Notes |
+| --- | --- |
+| `#p` | short; used throughout these docs |
+| `#param` | |
+| `#hbParam` | namespaced-ish |
+| `#HummingbirdMacroRoutingParam` | fully explicit; should be collision-proof |
+
+All four are enabled by default. If a shorter spelling still collides with something in your project, two **package traits** progressively disable the shorter names (which removes both the declaration *and* MacroRouting's recognition of that spelling, so your own same-named macro is left untouched):
+
+| Trait | Available spellings |
+| --- | --- |
+| *(none — default)* | `#p`, `#param`, `#hbParam`, `#HummingbirdMacroRoutingParam` |
+| `LongParamNamesOnly` | `#hbParam`, `#HummingbirdMacroRoutingParam` |
+| `ExplicitParamNameOnly` | `#HummingbirdMacroRoutingParam` |
+
+Enable a trait where you depend on the package:
+
+```swift
+.package(
+    url: "https://github.com/sloatescoan/hummingbird-macrorouting.git",
+    from: "…",
+    traits: ["LongParamNamesOnly"]
+)
+```
+
+You only need to remove (e.g.) `#p` if you already have a `#p` in scope, and if it has a different signature. MacroRouting will always use its own `#p` because the macro expansion code does not get access to your scope. The freestanding macro(s) that MacroRouting uses to resolve path parameters can't be overridden in your code.
 
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -198,10 +198,10 @@ The argument names are synthesized by MacroRouting, so they're available to well
 
 #### Typed path parameters
 
-By default, every synthesized `path(…)` argument is a `String`. You can give individual parameters a real Swift type with the `types:` argument, keyed by parameter name:
+By default, every synthesized `path(…)` argument is a `String`. You can give individual parameters a real Swift type with the `conform:` argument, keyed by parameter name. 
 
 ```swift
-    @GET("/users/{id}", types: ["id": UUID.self])
+    @GET("/users/{id}", conform: ["id": UUID.self])
     @Sendable func user(request: Request, context: Context) async throws -> Response {
         …
     }
@@ -215,14 +215,14 @@ let path = ApiController.$Routing.user.path(id: someUuid) // -> "/users/00000000
 
 The value's string-interpolation form (its `description`) is used to build the path—for `UUID` that is identical to `.uuidString`. This is the outbound mirror of Hummingbird's inbound `context.parameters.get(_:as:)`.
 
-Only the parameters you name in `types` are custom-typed; the rest stay `String`.
+Only the parameters you name in `conform:` get a custom type; the rest stay `String`.
 
 ```swift
-    @GET("/orgs/{orgId}/users/{userId}/tag/{tag}", types: ["orgId": UUID.self, "userId": Int.self])
+    @GET("/orgs/{orgId}/users/{userId}/tag/{tag}", conform: ["orgId": UUID.self, "userId": Int.self])
     // -> path(orgId: UUID, userId: Int, tag: String)
 ```
 
-Any type works as long as it conforms to `CustomStringConvertible`, *including your own project's types*—just conform them and pass them in `types:`:
+Any type works, so long as it conforms to `CustomStringConvertible`, *including your own project's types*—just conform them and pass them in `conform:`:
 
 ```swift
 struct Slug: CustomStringConvertible {
@@ -231,9 +231,11 @@ struct Slug: CustomStringConvertible {
 }
 
 // …
-    @GET("/post/{slug}", types: ["slug": Slug.self])
+    @GET("/post/{slug}", conform: ["slug": Slug.self])
     // -> path(slug: Slug)
 ```
+
+> **Important:** This does *not* affect how Hummingbird interprets a route/path, but it *does* provide a type-safe way to specify a route with `$Routing.pathHandler.path(…)`.
 
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -196,6 +196,46 @@ The argument names are synthesized by MacroRouting, so they're available to well
 
 ![IDE completion of `ApiController.$Routing.logs.path`](https://files.scoat.es/IKYWGNmUCq.gif)
 
+#### Typed path parameters
+
+By default, every synthesized `path(…)` argument is a `String`. You can give individual parameters a real Swift type with the `types:` argument, keyed by parameter name:
+
+```swift
+    @GET("/users/{id}", types: ["id": UUID.self])
+    @Sendable func user(request: Request, context: Context) async throws -> Response {
+        …
+    }
+```
+
+`ApiController.$Routing.user.path(id:)` now takes a `UUID`, so you can pass the value directly instead of stringifying at the call site:
+
+```swift
+let path = ApiController.$Routing.user.path(id: someUuid) // -> "/users/00000000-0000-0000-0000-000000000000"
+```
+
+The value's string-interpolation form (its `description`) is used to build the path—for `UUID` that is identical to `.uuidString`. This is the outbound mirror of Hummingbird's inbound `context.parameters.get(_:as:)`.
+
+Only the parameters you name in `types` are custom-typed; the rest stay `String`.
+
+```swift
+    @GET("/orgs/{orgId}/users/{userId}/tag/{tag}", types: ["orgId": UUID.self, "userId": Int.self])
+    // -> path(orgId: UUID, userId: Int, tag: String)
+```
+
+Any type works as long as it conforms to `CustomStringConvertible`, *including your own project's types*—just conform them and pass them in `types:`:
+
+```swift
+struct Slug: CustomStringConvertible {
+    let value: String
+    var description: String { value.lowercased() }
+}
+
+// …
+    @GET("/post/{slug}", types: ["slug": Slug.self])
+    // -> path(slug: Slug)
+```
+
+
 ## Tests
 
 There's some useful reference code available in the [test suite](https://github.com/sloatescoan/hummingbird-macrorouting/tree/main/Tests).

--- a/Sources/HummingbirdMacroRouting/attachment.swift
+++ b/Sources/HummingbirdMacroRouting/attachment.swift
@@ -2,19 +2,19 @@
 public macro MacroRouting(prefix: String? = nil) = #externalMacro(module: "RoutingMacros", type: "RoutingMacro")
 
 @attached(peer, names: arbitrary)
-public macro GET(_ path: String, name: String? = nil) = #externalMacro(module: "RoutingMacros", type: "GETMacro")
+public macro GET(_ path: String, name: String? = nil, types: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "GETMacro")
 
 @attached(peer, names: arbitrary)
-public macro POST(_ path: String, name: String? = nil) = #externalMacro(module: "RoutingMacros", type: "POSTMacro")
+public macro POST(_ path: String, name: String? = nil, types: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "POSTMacro")
 
 @attached(peer, names: arbitrary)
-public macro PUT(_ path: String, name: String? = nil) = #externalMacro(module: "RoutingMacros", type: "PUTMacro")
+public macro PUT(_ path: String, name: String? = nil, types: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "PUTMacro")
 
 @attached(peer, names: arbitrary)
-public macro DELETE(_ path: String, name: String? = nil) = #externalMacro(module: "RoutingMacros", type: "DELETEMacro")
+public macro DELETE(_ path: String, name: String? = nil, types: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "DELETEMacro")
 
 @attached(peer, names: arbitrary)
-public macro HEAD(_ path: String, name: String? = nil) = #externalMacro(module: "RoutingMacros", type: "HEADMacro")
+public macro HEAD(_ path: String, name: String? = nil, types: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "HEADMacro")
 
 @attached(peer, names: arbitrary)
-public macro PATCH(_ path: String, name: String? = nil) = #externalMacro(module: "RoutingMacros", type: "PATCHMacro")
+public macro PATCH(_ path: String, name: String? = nil, types: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "PATCHMacro")

--- a/Sources/HummingbirdMacroRouting/attachment.swift
+++ b/Sources/HummingbirdMacroRouting/attachment.swift
@@ -2,19 +2,19 @@
 public macro MacroRouting(prefix: String? = nil) = #externalMacro(module: "RoutingMacros", type: "RoutingMacro")
 
 @attached(peer, names: arbitrary)
-public macro GET(_ path: String, name: String? = nil, types: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "GETMacro")
+public macro GET(_ path: String, name: String? = nil, conform: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "GETMacro")
 
 @attached(peer, names: arbitrary)
-public macro POST(_ path: String, name: String? = nil, types: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "POSTMacro")
+public macro POST(_ path: String, name: String? = nil, conform: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "POSTMacro")
 
 @attached(peer, names: arbitrary)
-public macro PUT(_ path: String, name: String? = nil, types: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "PUTMacro")
+public macro PUT(_ path: String, name: String? = nil, conform: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "PUTMacro")
 
 @attached(peer, names: arbitrary)
-public macro DELETE(_ path: String, name: String? = nil, types: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "DELETEMacro")
+public macro DELETE(_ path: String, name: String? = nil, conform: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "DELETEMacro")
 
 @attached(peer, names: arbitrary)
-public macro HEAD(_ path: String, name: String? = nil, types: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "HEADMacro")
+public macro HEAD(_ path: String, name: String? = nil, conform: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "HEADMacro")
 
 @attached(peer, names: arbitrary)
-public macro PATCH(_ path: String, name: String? = nil, types: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "PATCHMacro")
+public macro PATCH(_ path: String, name: String? = nil, conform: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "PATCHMacro")

--- a/Sources/HummingbirdMacroRouting/attachment.swift
+++ b/Sources/HummingbirdMacroRouting/attachment.swift
@@ -1,20 +1,45 @@
 @attached(extension, names: arbitrary)
 public macro MacroRouting(prefix: String? = nil) = #externalMacro(module: "RoutingMacros", type: "RoutingMacro")
 
-@attached(peer, names: arbitrary)
-public macro GET(_ path: String, name: String? = nil, conform: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "GETMacro")
+// Used inside a route path to give a captured parameter a Swift type:
+//   @GET("/user/\(#p("id", UUID.self))")
+// It expands to the Hummingbird placeholder "{id}" and drives the type of the synthesized
+// `path(id: UUID)` builder. The type must conform to `CustomStringConvertible`.
+//
+// Four spellings are provided so a project can avoid a name collision. All are enabled by
+// default; the `LongParamNamesOnly` and `ExplicitParamNameOnly` package traits progressively
+// disable the shorter ones (see README).
+
+#if !ExplicitParamNameOnly && !LongParamNamesOnly
+@freestanding(expression)
+public macro p(_ name: String, _ type: any CustomStringConvertible.Type) -> String = #externalMacro(module: "RoutingMacros", type: "ParamMacro")
+
+@freestanding(expression)
+public macro param(_ name: String, _ type: any CustomStringConvertible.Type) -> String = #externalMacro(module: "RoutingMacros", type: "ParamMacro")
+#endif
+
+#if !ExplicitParamNameOnly
+@freestanding(expression)
+public macro hbParam(_ name: String, _ type: any CustomStringConvertible.Type) -> String = #externalMacro(module: "RoutingMacros", type: "ParamMacro")
+#endif
+
+@freestanding(expression)
+public macro HummingbirdMacroRoutingParam(_ name: String, _ type: any CustomStringConvertible.Type) -> String = #externalMacro(module: "RoutingMacros", type: "ParamMacro")
 
 @attached(peer, names: arbitrary)
-public macro POST(_ path: String, name: String? = nil, conform: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "POSTMacro")
+public macro GET(_ path: String, name: String? = nil) = #externalMacro(module: "RoutingMacros", type: "GETMacro")
 
 @attached(peer, names: arbitrary)
-public macro PUT(_ path: String, name: String? = nil, conform: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "PUTMacro")
+public macro POST(_ path: String, name: String? = nil) = #externalMacro(module: "RoutingMacros", type: "POSTMacro")
 
 @attached(peer, names: arbitrary)
-public macro DELETE(_ path: String, name: String? = nil, conform: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "DELETEMacro")
+public macro PUT(_ path: String, name: String? = nil) = #externalMacro(module: "RoutingMacros", type: "PUTMacro")
 
 @attached(peer, names: arbitrary)
-public macro HEAD(_ path: String, name: String? = nil, conform: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "HEADMacro")
+public macro DELETE(_ path: String, name: String? = nil) = #externalMacro(module: "RoutingMacros", type: "DELETEMacro")
 
 @attached(peer, names: arbitrary)
-public macro PATCH(_ path: String, name: String? = nil, conform: [String: any CustomStringConvertible.Type] = [:]) = #externalMacro(module: "RoutingMacros", type: "PATCHMacro")
+public macro HEAD(_ path: String, name: String? = nil) = #externalMacro(module: "RoutingMacros", type: "HEADMacro")
+
+@attached(peer, names: arbitrary)
+public macro PATCH(_ path: String, name: String? = nil) = #externalMacro(module: "RoutingMacros", type: "PATCHMacro")

--- a/Sources/RoutingMacros/DiagnosticMessages.swift
+++ b/Sources/RoutingMacros/DiagnosticMessages.swift
@@ -29,7 +29,7 @@ struct MsgParamNameError: DiagnosticMessage {
     let severity: DiagnosticSeverity = .error
     let message: String
     init(name: String) {
-        self.message = "The parameter name '\(name)' must be a valid Swift identifier (it becomes both a path placeholder and a path(…) argument label)"
+        self.message = "The parameter name '\(name)' can't contain '/', '{', '}', a backtick or backslash, and can't be empty or all-whitespace (it becomes both a path placeholder and a path(…) argument label)"
     }
 }
 

--- a/Sources/RoutingMacros/DiagnosticMessages.swift
+++ b/Sources/RoutingMacros/DiagnosticMessages.swift
@@ -20,7 +20,7 @@ struct MsgUnknownPathParameter: DiagnosticMessage {
     let severity: DiagnosticSeverity = .error
     let message: String
     init(name: String) {
-        self.message = "Parameter '\(name)' in types: is not a captured path parameter"
+        self.message = "Parameter '\(name)' in conform: is not a captured path parameter"
     }
 }
 

--- a/Sources/RoutingMacros/DiagnosticMessages.swift
+++ b/Sources/RoutingMacros/DiagnosticMessages.swift
@@ -15,15 +15,6 @@ struct MsgNameConflict: DiagnosticMessage {
     }
 }
 
-struct MsgUnknownPathParameter: DiagnosticMessage {
-    let diagnosticID = MessageID(domain: "MacroRouting", id: "unknownPathParameter")
-    let severity: DiagnosticSeverity = .error
-    let message: String
-    init(name: String) {
-        self.message = "Parameter '\(name)' in conform: is not a captured path parameter"
-    }
-}
-
 struct MsgNameError: DiagnosticMessage {
     let diagnosticID = MessageID(domain: "MacroRouting", id: "nameError")
     let severity: DiagnosticSeverity = .error

--- a/Sources/RoutingMacros/DiagnosticMessages.swift
+++ b/Sources/RoutingMacros/DiagnosticMessages.swift
@@ -15,6 +15,15 @@ struct MsgNameConflict: DiagnosticMessage {
     }
 }
 
+struct MsgUnknownPathParameter: DiagnosticMessage {
+    let diagnosticID = MessageID(domain: "MacroRouting", id: "unknownPathParameter")
+    let severity: DiagnosticSeverity = .error
+    let message: String
+    init(name: String) {
+        self.message = "Parameter '\(name)' in types: is not a captured path parameter"
+    }
+}
+
 struct MsgNameError: DiagnosticMessage {
     let diagnosticID = MessageID(domain: "MacroRouting", id: "nameError")
     let severity: DiagnosticSeverity = .error

--- a/Sources/RoutingMacros/DiagnosticMessages.swift
+++ b/Sources/RoutingMacros/DiagnosticMessages.swift
@@ -23,3 +23,21 @@ struct MsgNameError: DiagnosticMessage {
         self.message = "The name associated with this route ('\(name)') must be a valid Swift identifier"
     }
 }
+
+struct MsgParamNameError: DiagnosticMessage {
+    let diagnosticID = MessageID(domain: "MacroRouting", id: "paramNameError")
+    let severity: DiagnosticSeverity = .error
+    let message: String
+    init(name: String) {
+        self.message = "The parameter name '\(name)' must be a valid Swift identifier (it becomes both a path placeholder and a path(…) argument label)"
+    }
+}
+
+struct MsgParamTypeConflict: DiagnosticMessage {
+    let diagnosticID = MessageID(domain: "MacroRouting", id: "paramTypeConflict")
+    let severity: DiagnosticSeverity = .error
+    let message: String
+    init(name: String, existing: String, new: String) {
+        self.message = "Path parameter '\(name)' is declared with conflicting types ('\(existing)' and '\(new)'); repeated parameters collapse into a single path(…) argument and must agree on their type"
+    }
+}

--- a/Sources/RoutingMacros/RoutingMacros.swift
+++ b/Sources/RoutingMacros/RoutingMacros.swift
@@ -27,7 +27,7 @@ struct CapturedRoute {
     let handler: String
     let name: String
     let function: FunctionDeclSyntax
-    // param name -> explicit Swift type from the `types:` argument (defaults to String when absent)
+    // param name -> explicit Swift type from the `conform:` argument (defaults to String when absent)
     let paramTypes: [String: String]
 
     static func stripped(_ val: String) -> String {
@@ -125,11 +125,11 @@ public struct RoutingMacro: ExtensionMacro {
                     name = function.name.text
                 }
 
-                // Extract the optional `types:` dictionary mapping path parameter names to Swift types.
+                // Extract the optional `conform:` dictionary mapping path parameter names to Swift types.
                 var paramTypes: [String: String] = [:]
                 if
-                    let typesExpr = arguments.first(where: { $0.label?.text == "types" })?.expression.as(DictionaryExprSyntax.self),
-                    case let .elements(elements) = typesExpr.content
+                    let conformExpr = arguments.first(where: { $0.label?.text == "conform" })?.expression.as(DictionaryExprSyntax.self),
+                    case let .elements(elements) = conformExpr.content
                 {
                     for element in elements {
                         guard
@@ -219,7 +219,7 @@ public struct RoutingMacro: ExtensionMacro {
                 }
             }
 
-            // A `types:` key that doesn't match a captured parameter is almost certainly a typo.
+            // A `conform:` key that doesn't match a captured parameter is almost certainly a typo.
             for typedParam in route.paramTypes.keys where !captured.contains(typedParam) {
                 context.diagnose(
                     Diagnostic(

--- a/Sources/RoutingMacros/RoutingMacros.swift
+++ b/Sources/RoutingMacros/RoutingMacros.swift
@@ -55,6 +55,31 @@ let paramMacroNames: Set<String> = {
     return names
 }()
 
+// Is `name` usable as a *bare* Swift identifier (no backticks needed)? Approximates Swift's
+// identifier grammar and covers Unicode letters; keywords also satisfy this by their characters.
+func isBareIdentifier(_ name: String) -> Bool {
+    guard let first = name.first, first == "_" || first.isLetter else { return false }
+    return name.dropFirst().allSatisfy { $0 == "_" || $0.isLetter || $0.isNumber }
+}
+
+// A path parameter name may be anything Hummingbird accepts, except characters that would break the
+// route path structure (`{`, `}`, `/`) or the generated Swift / string literals (backtick, backslash,
+// newlines). It also may not be empty or all-whitespace.
+func isValidParamName(_ name: String) -> Bool {
+    guard name.contains(where: { !$0.isWhitespace }) else { return false }
+    return !name.contains { "{}/`\\".contains($0) || $0.isNewline }
+}
+
+// Emit `name` as an argument *label*: bare when it's already a valid identifier (keywords are legal
+// bare labels too), backticked otherwise (raw identifiers — spaces, hyphens, digit-leads, …).
+func labelToken(_ name: String) -> String { isBareIdentifier(name) ? name : "`\(name)`" }
+
+// Emit `name` as a *value* reference: bare only for a plain identifier; keywords and raw identifiers
+// must be backticked to be referenced as an expression.
+func valueToken(_ name: String) -> String {
+    (isBareIdentifier(name) && ReservedWord(rawValue: name) == nil) ? name : "`\(name)`"
+}
+
 struct CapturedRoute {
     let method: Method
     let path: String
@@ -185,9 +210,10 @@ public struct RoutingMacro: ExtensionMacro {
                         let paramName = call.arguments.first?.expression.as(StringLiteralExprSyntax.self)?
                             .segments.first?.as(StringSegmentSyntax.self)?.content.text
                     {
-                        // The name becomes both a `{name}` path placeholder and a `path(name:)` argument
-                        // label, so it must be a plain identifier — reject spaces, braces, slashes, etc.
-                        guard paramName.range(of: #"^[A-Za-z_][A-Za-z0-9_]*$"#, options: .regularExpression) != nil else {
+                        // The name becomes both a `{name}` placeholder and a `path(name:)` argument
+                        // label. We allow anything Hummingbird does, except characters that break the
+                        // path structure or the generated code (see isValidParamName).
+                        guard isValidParamName(paramName) else {
                             context.diagnose(Diagnostic(node: call, message: MsgParamNameError(name: paramName)))
                             return nil
                         }
@@ -282,17 +308,17 @@ public struct RoutingMacro: ExtensionMacro {
                     let name = String(comp[comp.index(after: comp.startIndex)..<close])
                     let suffix = String(comp[comp.index(after: close)...])
                     captured.append(name)
-                    out.append("\\(`" + name + "`)" + suffix)
+                    out.append("\\(" + valueToken(name) + ")" + suffix)
                 } else if comp.last == "}", let open = comp.lastIndex(of: "{"), open != comp.startIndex {
                     // A literal prefix followed by `{name}` — Hummingbird's suffix-capture, e.g. `file{ext}`.
                     let prefixLiteral = String(comp[..<open])
                     let name = String(comp[comp.index(after: open)..<comp.index(before: comp.endIndex)])
                     captured.append(name)
-                    out.append(prefixLiteral + "\\(`" + name + "`)")
+                    out.append(prefixLiteral + "\\(" + valueToken(name) + ")")
                 } else if comp.first == ":" {
                     let name = String(comp.dropFirst())
                     captured.append(name)
-                    out.append("\\(`" + name + "`)")
+                    out.append("\\(" + valueToken(name) + ")")
                 } else {
                     // literal component, including wildcards (*, **, *.jpg, file.*) which bind no argument
                     out.append(comp)
@@ -322,15 +348,10 @@ public struct RoutingMacro: ExtensionMacro {
                 // for routes that have captured arguments, provide path(…) (formerly resolvedPath(…))
                 code += """
                     @available(*, deprecated, renamed: "path", message: "resolvedPath(…) has been renamed to path(…)")
-                    static func resolvedPath(\(uniqueCaptured.map({ "\($0): \(typeFor($0))"}).joined(separator: ", "))) -> String {
-                        path(\(uniqueCaptured.map({
-                            ReservedWord(rawValue: $0) == nil ?
-                                "\($0): \($0)"
-                                :
-                                "`\($0)`: `\($0)`"
-                        }).joined(separator: ", ")))
+                    static func resolvedPath(\(uniqueCaptured.map({ "\(labelToken($0)): \(typeFor($0))"}).joined(separator: ", "))) -> String {
+                        path(\(uniqueCaptured.map({ "\(labelToken($0)): \(valueToken($0))" }).joined(separator: ", ")))
                     }
-                    static func path(\(uniqueCaptured.map({ "\($0): \(typeFor($0))"}).joined(separator: ", "))) -> String {
+                    static func path(\(uniqueCaptured.map({ "\(labelToken($0)): \(typeFor($0))"}).joined(separator: ", "))) -> String {
                         "/\(out.joined(separator: "/"))"
                     }
                 """

--- a/Sources/RoutingMacros/RoutingMacros.swift
+++ b/Sources/RoutingMacros/RoutingMacros.swift
@@ -14,12 +14,46 @@ struct RoutingMacros: CompilerPlugin {
         HEADMacro.self,
         PATCHMacro.self,
         RoutingMacro.self,
+        ParamMacro.self,
     ]
+}
+
+// Freestanding expression macro used inside a route path: `\(#param("id", UUID.self))`.
+// It expands to the string literal "{id}" so the surrounding path type-checks as a String and
+// its runtime value is the Hummingbird placeholder. RoutingMacro reads the (unexpanded) call
+// out of the path's syntax to recover both the parameter name and its Swift type.
+public struct ParamMacro: ExpressionMacro {
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> ExprSyntax {
+        guard
+            let name = node.arguments.first?.expression.as(StringLiteralExprSyntax.self)?
+                .segments.first?.as(StringSegmentSyntax.self)?.content.text
+        else {
+            return "\"{}\""
+        }
+        return "\"{\(raw: name)}\""
+    }
 }
 enum Method: String, CaseIterable {
     case get, post, put, delete, head, patch
     static var allValues: [String] { Self.allCases.map { "\($0)".uppercased() } }
 }
+
+// The spellings RoutingMacro recognizes as the path-parameter macro. Gated by the same package
+// traits that gate the declarations, so a disabled name is no longer claimed as ours.
+let paramMacroNames: Set<String> = {
+    var names: Set<String> = ["HummingbirdMacroRoutingParam"]
+    #if !ExplicitParamNameOnly
+    names.insert("hbParam")
+    #endif
+    #if !ExplicitParamNameOnly && !LongParamNamesOnly
+    names.insert("p")
+    names.insert("param")
+    #endif
+    return names
+}()
 
 struct CapturedRoute {
     let method: Method
@@ -27,7 +61,7 @@ struct CapturedRoute {
     let handler: String
     let name: String
     let function: FunctionDeclSyntax
-    // param name -> explicit Swift type from the `conform:` argument (defaults to String when absent)
+    // param name -> explicit Swift type from a `#param(…)` in the path (defaults to String when absent)
     let paramTypes: [String: String]
 
     static func stripped(_ val: String) -> String {
@@ -92,8 +126,7 @@ public struct RoutingMacro: ExtensionMacro {
                     let arguments = httpAttribute.arguments?.as(LabeledExprListSyntax.self),
                     let firstArg = arguments.first?.expression.as(StringLiteralExprSyntax.self),
                     let methodName = httpAttribute.attributeName.as(IdentifierTypeSyntax.self)?.name.text,
-                    let method = Method(rawValue: methodName.lowercased()),
-                    let path = firstArg.segments.first?.as(StringSegmentSyntax.self)?.content.text
+                    let method = Method(rawValue: methodName.lowercased())
                 else {
                     context.diagnose(
                         Diagnostic(
@@ -125,30 +158,49 @@ public struct RoutingMacro: ExtensionMacro {
                     name = function.name.text
                 }
 
-                // Extract the optional `conform:` dictionary mapping path parameter names to Swift types.
+                // Reconstruct the path from the string literal's segments. Plain text passes through;
+                // each `#param("name", Type.self)` interpolation contributes a `{name}` placeholder
+                // (what Hummingbird sees) and records the Swift type for the synthesized `path(…)`.
+                var path = ""
                 var paramTypes: [String: String] = [:]
-                if
-                    let conformExpr = arguments.first(where: { $0.label?.text == "conform" })?.expression.as(DictionaryExprSyntax.self),
-                    case let .elements(elements) = conformExpr.content
-                {
-                    for element in elements {
+                var malformedInterpolation = false
+                for segment in firstArg.segments {
+                    if let str = segment.as(StringSegmentSyntax.self) {
+                        path += str.content.text
+                    } else if let expr = segment.as(ExpressionSegmentSyntax.self) {
                         guard
-                            let key = element.key.as(StringLiteralExprSyntax.self)?
+                            let call = expr.expressions.first?.expression.as(MacroExpansionExprSyntax.self),
+                            paramMacroNames.contains(call.macroName.text),
+                            let paramName = call.arguments.first?.expression.as(StringLiteralExprSyntax.self)?
                                 .segments.first?.as(StringSegmentSyntax.self)?.content.text
-                        else { continue }
-                        // Values look like `UUID.self`; take the base (`UUID`) as the type name.
+                        else {
+                            malformedInterpolation = true
+                            break
+                        }
+                        // The second argument is a `Type.self` metatype; take its base as the type name.
                         let typeName: String
                         if
-                            let member = element.value.as(MemberAccessExprSyntax.self),
-                            member.declName.baseName.text == "self",
-                            let base = member.base
+                            let typeExpr = call.arguments.dropFirst().first?.expression.as(MemberAccessExprSyntax.self),
+                            typeExpr.declName.baseName.text == "self",
+                            let base = typeExpr.base
                         {
                             typeName = base.trimmedDescription
+                        } else if let typeExpr = call.arguments.dropFirst().first?.expression {
+                            typeName = typeExpr.trimmedDescription
                         } else {
-                            typeName = element.value.trimmedDescription
+                            malformedInterpolation = true
+                            break
                         }
-                        paramTypes[key] = typeName
+                        path += "{\(paramName)}"
+                        paramTypes[paramName] = typeName
+                    } else {
+                        malformedInterpolation = true
+                        break
                     }
+                }
+                guard !malformedInterpolation else {
+                    context.diagnose(Diagnostic(node: member.decl, message: MsgMalformed()))
+                    return nil
                 }
 
                 return CapturedRoute(method: method, path: path, handler: function.name.text, name: name, function: function, paramTypes: paramTypes)
@@ -217,16 +269,6 @@ public struct RoutingMacro: ExtensionMacro {
                     // there are other types like wildcards, but those are harder to replace
                     out.append(component.description)
                 }
-            }
-
-            // A `conform:` key that doesn't match a captured parameter is almost certainly a typo.
-            for typedParam in route.paramTypes.keys where !captured.contains(typedParam) {
-                context.diagnose(
-                    Diagnostic(
-                        node: route.function,
-                        message: MsgUnknownPathParameter(name: typedParam)
-                    )
-                )
             }
 
             // Resolve each captured parameter's declared type, defaulting to String.

--- a/Sources/RoutingMacros/RoutingMacros.swift
+++ b/Sources/RoutingMacros/RoutingMacros.swift
@@ -27,6 +27,8 @@ struct CapturedRoute {
     let handler: String
     let name: String
     let function: FunctionDeclSyntax
+    // param name -> explicit Swift type from the `types:` argument (defaults to String when absent)
+    let paramTypes: [String: String]
 
     static func stripped(_ val: String) -> String {
         var val = val
@@ -39,12 +41,13 @@ struct CapturedRoute {
         return val
     }
 
-    init(method: Method, path: String, handler: String, name: String, function: FunctionDeclSyntax) {
+    init(method: Method, path: String, handler: String, name: String, function: FunctionDeclSyntax, paramTypes: [String: String] = [:]) {
         self.method = method
         self.path = Self.stripped(path)
         self.handler = Self.stripped(handler)
         self.name = Self.stripped(name)
         self.function = function
+        self.paramTypes = paramTypes
     }
 }
 
@@ -122,8 +125,33 @@ public struct RoutingMacro: ExtensionMacro {
                     name = function.name.text
                 }
 
+                // Extract the optional `types:` dictionary mapping path parameter names to Swift types.
+                var paramTypes: [String: String] = [:]
+                if
+                    let typesExpr = arguments.first(where: { $0.label?.text == "types" })?.expression.as(DictionaryExprSyntax.self),
+                    case let .elements(elements) = typesExpr.content
+                {
+                    for element in elements {
+                        guard
+                            let key = element.key.as(StringLiteralExprSyntax.self)?
+                                .segments.first?.as(StringSegmentSyntax.self)?.content.text
+                        else { continue }
+                        // Values look like `UUID.self`; take the base (`UUID`) as the type name.
+                        let typeName: String
+                        if
+                            let member = element.value.as(MemberAccessExprSyntax.self),
+                            member.declName.baseName.text == "self",
+                            let base = member.base
+                        {
+                            typeName = base.trimmedDescription
+                        } else {
+                            typeName = element.value.trimmedDescription
+                        }
+                        paramTypes[key] = typeName
+                    }
+                }
 
-                return CapturedRoute(method: method, path: path, handler: function.name.text, name: name, function: function)
+                return CapturedRoute(method: method, path: path, handler: function.name.text, name: name, function: function, paramTypes: paramTypes)
             }
         }
 
@@ -191,6 +219,19 @@ public struct RoutingMacro: ExtensionMacro {
                 }
             }
 
+            // A `types:` key that doesn't match a captured parameter is almost certainly a typo.
+            for typedParam in route.paramTypes.keys where !captured.contains(typedParam) {
+                context.diagnose(
+                    Diagnostic(
+                        node: route.function,
+                        message: MsgUnknownPathParameter(name: typedParam)
+                    )
+                )
+            }
+
+            // Resolve each captured parameter's declared type, defaulting to String.
+            func typeFor(_ param: String) -> String { route.paramTypes[param] ?? "String" }
+
             code += """
                 struct `\(route.name)`: MacroRoutingRoute {
                     private init() {}
@@ -205,7 +246,7 @@ public struct RoutingMacro: ExtensionMacro {
                 // for routes that have captured arguments, provide path(…) (formerly resolvedPath(…))
                 code += """
                     @available(*, deprecated, renamed: "path", message: "resolvedPath(…) has been renamed to path(…)")
-                    static func resolvedPath(\(captured.map({ "\($0): String"}).joined(separator: ", "))) -> String {
+                    static func resolvedPath(\(captured.map({ "\($0): \(typeFor($0))"}).joined(separator: ", "))) -> String {
                         path(\(captured.map({
                             ReservedWord(rawValue: $0) == nil ?
                                 "\($0): \($0)"
@@ -213,7 +254,7 @@ public struct RoutingMacro: ExtensionMacro {
                                 "`\($0)`: `\($0)`"
                         }).joined(separator: ", ")))
                     }
-                    static func path(\(captured.map({ "\($0): String"}).joined(separator: ", "))) -> String {
+                    static func path(\(captured.map({ "\($0): \(typeFor($0))"}).joined(separator: ", "))) -> String {
                         "/\(out.joined(separator: "/"))"
                     }
                 """

--- a/Sources/RoutingMacros/RoutingMacros.swift
+++ b/Sources/RoutingMacros/RoutingMacros.swift
@@ -185,6 +185,12 @@ public struct RoutingMacro: ExtensionMacro {
                         let paramName = call.arguments.first?.expression.as(StringLiteralExprSyntax.self)?
                             .segments.first?.as(StringSegmentSyntax.self)?.content.text
                     {
+                        // The name becomes both a `{name}` path placeholder and a `path(name:)` argument
+                        // label, so it must be a plain identifier — reject spaces, braces, slashes, etc.
+                        guard paramName.range(of: #"^[A-Za-z_][A-Za-z0-9_]*$"#, options: .regularExpression) != nil else {
+                            context.diagnose(Diagnostic(node: call, message: MsgParamNameError(name: paramName)))
+                            return nil
+                        }
                         // The second argument is a `Type.self` metatype; take its base as the type name.
                         let typeName: String
                         if
@@ -195,6 +201,12 @@ public struct RoutingMacro: ExtensionMacro {
                             typeName = base.trimmedDescription
                         } else {
                             typeName = call.arguments.dropFirst().first?.expression.trimmedDescription ?? "String"
+                        }
+                        // A repeated parameter collapses into one path(…) argument, so its type must
+                        // agree across occurrences.
+                        if let existing = paramTypes[paramName], existing != typeName {
+                            context.diagnose(Diagnostic(node: call, message: MsgParamTypeConflict(name: paramName, existing: existing, new: typeName)))
+                            return nil
                         }
                         path += "{\(paramName)}"
                         paramTypes[paramName] = typeName
@@ -263,19 +275,35 @@ public struct RoutingMacro: ExtensionMacro {
             let prefixedPath = "\(prefix ?? "")\(route.path)"
 
             for component in prefixedPath.split(separator: "/") {
-                if component.first == "{" {
-                    let name = String(component.dropFirst().dropLast())
+                let comp = String(component)
+                if comp.first == "{", let close = comp.firstIndex(of: "}") {
+                    // `{name}` optionally followed by a literal suffix — Hummingbird's prefix-capture,
+                    // e.g. `{id}.jpg` (param `id`, literal `.jpg`).
+                    let name = String(comp[comp.index(after: comp.startIndex)..<close])
+                    let suffix = String(comp[comp.index(after: close)...])
                     captured.append(name)
-                    out.append("\\(`" + name + "`)")
-                } else if component.first == ":" {
-                    let name = String(component.dropFirst())
+                    out.append("\\(`" + name + "`)" + suffix)
+                } else if comp.last == "}", let open = comp.lastIndex(of: "{"), open != comp.startIndex {
+                    // A literal prefix followed by `{name}` — Hummingbird's suffix-capture, e.g. `file{ext}`.
+                    let prefixLiteral = String(comp[..<open])
+                    let name = String(comp[comp.index(after: open)..<comp.index(before: comp.endIndex)])
+                    captured.append(name)
+                    out.append(prefixLiteral + "\\(`" + name + "`)")
+                } else if comp.first == ":" {
+                    let name = String(comp.dropFirst())
                     captured.append(name)
                     out.append("\\(`" + name + "`)")
                 } else {
-                    // there are other types like wildcards, but those are harder to replace
-                    out.append(component.description)
+                    // literal component, including wildcards (*, **, *.jpg, file.*) which bind no argument
+                    out.append(comp)
                 }
             }
+
+            // A parameter may appear more than once in a path (e.g. `/x/{foo}/y/{foo}`). Those
+            // occurrences collapse into a single path(…) argument that fills every position, so the
+            // signature uses each name once (first-occurrence order) while `out` keeps every position.
+            var seenCapture: Set<String> = []
+            let uniqueCaptured = captured.filter { seenCapture.insert($0).inserted }
 
             // Resolve each captured parameter's declared type, defaulting to String.
             func typeFor(_ param: String) -> String { route.paramTypes[param] ?? "String" }
@@ -290,19 +318,19 @@ public struct RoutingMacro: ExtensionMacro {
                     static let rawPath: String = "\(route.path)"
             """
 
-            if captured.count > 0 {
+            if uniqueCaptured.count > 0 {
                 // for routes that have captured arguments, provide path(…) (formerly resolvedPath(…))
                 code += """
                     @available(*, deprecated, renamed: "path", message: "resolvedPath(…) has been renamed to path(…)")
-                    static func resolvedPath(\(captured.map({ "\($0): \(typeFor($0))"}).joined(separator: ", "))) -> String {
-                        path(\(captured.map({
+                    static func resolvedPath(\(uniqueCaptured.map({ "\($0): \(typeFor($0))"}).joined(separator: ", "))) -> String {
+                        path(\(uniqueCaptured.map({
                             ReservedWord(rawValue: $0) == nil ?
                                 "\($0): \($0)"
                                 :
                                 "`\($0)`: `\($0)`"
                         }).joined(separator: ", ")))
                     }
-                    static func path(\(captured.map({ "\($0): \(typeFor($0))"}).joined(separator: ", "))) -> String {
+                    static func path(\(uniqueCaptured.map({ "\($0): \(typeFor($0))"}).joined(separator: ", "))) -> String {
                         "/\(out.joined(separator: "/"))"
                     }
                 """

--- a/Sources/RoutingMacros/RoutingMacros.swift
+++ b/Sources/RoutingMacros/RoutingMacros.swift
@@ -146,10 +146,6 @@ public struct RoutingMacro: ExtensionMacro {
                     return nil
                 }
 
-                // Preserve any `\(…)` interpolation in the path so it passes
-                // through to the generated code instead of truncating.
-                let path = reconstructedLiteral(firstArg)
-
                 // Extract the route name
                 let name: String
                 if
@@ -174,25 +170,21 @@ public struct RoutingMacro: ExtensionMacro {
                     name = function.name.text
                 }
 
-                // Reconstruct the path from the string literal's segments. Plain text passes through;
-                // each `#param("name", Type.self)` interpolation contributes a `{name}` placeholder
-                // (what Hummingbird sees) and records the Swift type for the synthesized `path(…)`.
+                // Reconstruct the path from the string literal's segments. A `#param("name", Type.self)`
+                // interpolation contributes a `{name}` placeholder (what Hummingbird sees) and records
+                // the Swift type for the synthesized `path(…)`. Every other segment — plain text and any
+                // other `\(…)` interpolation, e.g. `\(API.version)` — is emitted verbatim so it passes
+                // through to the generated code (matching `reconstructedLiteral`).
                 var path = ""
                 var paramTypes: [String: String] = [:]
-                var malformedInterpolation = false
                 for segment in firstArg.segments {
-                    if let str = segment.as(StringSegmentSyntax.self) {
-                        path += str.content.text
-                    } else if let expr = segment.as(ExpressionSegmentSyntax.self) {
-                        guard
-                            let call = expr.expressions.first?.expression.as(MacroExpansionExprSyntax.self),
-                            paramMacroNames.contains(call.macroName.text),
-                            let paramName = call.arguments.first?.expression.as(StringLiteralExprSyntax.self)?
-                                .segments.first?.as(StringSegmentSyntax.self)?.content.text
-                        else {
-                            malformedInterpolation = true
-                            break
-                        }
+                    if
+                        let expr = segment.as(ExpressionSegmentSyntax.self),
+                        let call = expr.expressions.first?.expression.as(MacroExpansionExprSyntax.self),
+                        paramMacroNames.contains(call.macroName.text),
+                        let paramName = call.arguments.first?.expression.as(StringLiteralExprSyntax.self)?
+                            .segments.first?.as(StringSegmentSyntax.self)?.content.text
+                    {
                         // The second argument is a `Type.self` metatype; take its base as the type name.
                         let typeName: String
                         if
@@ -201,22 +193,14 @@ public struct RoutingMacro: ExtensionMacro {
                             let base = typeExpr.base
                         {
                             typeName = base.trimmedDescription
-                        } else if let typeExpr = call.arguments.dropFirst().first?.expression {
-                            typeName = typeExpr.trimmedDescription
                         } else {
-                            malformedInterpolation = true
-                            break
+                            typeName = call.arguments.dropFirst().first?.expression.trimmedDescription ?? "String"
                         }
                         path += "{\(paramName)}"
                         paramTypes[paramName] = typeName
                     } else {
-                        malformedInterpolation = true
-                        break
+                        path += segment.description
                     }
-                }
-                guard !malformedInterpolation else {
-                    context.diagnose(Diagnostic(node: member.decl, message: MsgMalformed()))
-                    return nil
                 }
 
                 return CapturedRoute(method: method, path: path, handler: function.name.text, name: name, function: function, paramTypes: paramTypes)

--- a/Tests/Sources/PathAgumentsMacroRoutingController.swift
+++ b/Tests/Sources/PathAgumentsMacroRoutingController.swift
@@ -134,4 +134,15 @@ struct PathArgumentsMacroRoutingController {
     @Sendable func repeatedParam(request: Request, context: Context) async throws -> Response {
         return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "repeated")))
     }
+
+    // Loose names that Hummingbird allows — supported via backticked (raw) identifiers.
+    @GET("/space/\(#p("user id", String.self))")
+    @Sendable func spacedName(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "spaced")))
+    }
+
+    @GET("/dash/\(#p("user-id", String.self))")
+    @Sendable func dashedName(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "dashed")))
+    }
 }

--- a/Tests/Sources/PathAgumentsMacroRoutingController.swift
+++ b/Tests/Sources/PathAgumentsMacroRoutingController.swift
@@ -2,7 +2,7 @@ import Foundation
 import Hummingbird
 import HummingbirdMacroRouting
 
-// A project-defined type used in `types:` to accept custom CustomStringConvertible
+// A project-defined type used in `conform:` to accept custom CustomStringConvertible
 struct Slug: CustomStringConvertible {
     let value: String
     var description: String { value.lowercased() }
@@ -69,7 +69,7 @@ struct PathArgumentsMacroRoutingController {
     }
 
     // A single typed parameter (UUID from Foundation).
-    @GET("/user/{id}", types: ["id": UUID.self])
+    @GET("/user/{id}", conform: ["id": UUID.self])
     @Sendable func user(request: Request, context: Context) async throws -> Response {
         return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(
             string: "User {id} = \(context.parameters.get("id", as: String.self) ?? "nil")"
@@ -77,7 +77,7 @@ struct PathArgumentsMacroRoutingController {
     }
 
     // Mixed typed parameters, plus an untyped one that defaults to String.
-    @GET("/org/{orgId}/user/{userId}/tag/{tag}", types: ["orgId": UUID.self, "userId": Int.self])
+    @GET("/org/{orgId}/user/{userId}/tag/{tag}", conform: ["orgId": UUID.self, "userId": Int.self])
     @Sendable func orgUser(request: Request, context: Context) async throws -> Response {
         return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(
             string: "OrgUser = "
@@ -88,7 +88,7 @@ struct PathArgumentsMacroRoutingController {
     }
 
     // A project-defined CustomStringConvertible type.
-    @GET("/post/{slug}", types: ["slug": Slug.self])
+    @GET("/post/{slug}", conform: ["slug": Slug.self])
     @Sendable func post(request: Request, context: Context) async throws -> Response {
         return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(
             string: "Post {slug} = \(context.parameters.get("slug", as: String.self) ?? "nil")"

--- a/Tests/Sources/PathAgumentsMacroRoutingController.swift
+++ b/Tests/Sources/PathAgumentsMacroRoutingController.swift
@@ -1,5 +1,12 @@
+import Foundation
 import Hummingbird
 import HummingbirdMacroRouting
+
+// A project-defined type used in `types:` to accept custom CustomStringConvertible
+struct Slug: CustomStringConvertible {
+    let value: String
+    var description: String { value.lowercased() }
+}
 
 @MacroRouting
 struct PathArgumentsMacroRoutingController {
@@ -58,6 +65,33 @@ struct PathArgumentsMacroRoutingController {
                 + "\(context.parameters.get("three", as: String.self) ?? "nil")/"
                 + "\(context.parameters.get("four", as: String.self) ?? "nil")/"
                 + "\(context.parameters.get("five", as: String.self) ?? "nil")"
+        )))
+    }
+
+    // A single typed parameter (UUID from Foundation).
+    @GET("/user/{id}", types: ["id": UUID.self])
+    @Sendable func user(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(
+            string: "User {id} = \(context.parameters.get("id", as: String.self) ?? "nil")"
+        )))
+    }
+
+    // Mixed typed parameters, plus an untyped one that defaults to String.
+    @GET("/org/{orgId}/user/{userId}/tag/{tag}", types: ["orgId": UUID.self, "userId": Int.self])
+    @Sendable func orgUser(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(
+            string: "OrgUser = "
+                + "\(context.parameters.get("orgId", as: String.self) ?? "nil")/"
+                + "\(context.parameters.get("userId", as: String.self) ?? "nil")/"
+                + "\(context.parameters.get("tag", as: String.self) ?? "nil")"
+        )))
+    }
+
+    // A project-defined CustomStringConvertible type.
+    @GET("/post/{slug}", types: ["slug": Slug.self])
+    @Sendable func post(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(
+            string: "Post {slug} = \(context.parameters.get("slug", as: String.self) ?? "nil")"
         )))
     }
 }

--- a/Tests/Sources/PathAgumentsMacroRoutingController.swift
+++ b/Tests/Sources/PathAgumentsMacroRoutingController.swift
@@ -2,7 +2,7 @@ import Foundation
 import Hummingbird
 import HummingbirdMacroRouting
 
-// A project-defined type used in `conform:` to accept custom CustomStringConvertible
+// A project-defined type used with `#p` to accept a custom CustomStringConvertible type.
 struct Slug: CustomStringConvertible {
     let value: String
     var description: String { value.lowercased() }
@@ -69,15 +69,15 @@ struct PathArgumentsMacroRoutingController {
     }
 
     // A single typed parameter (UUID from Foundation).
-    @GET("/user/{id}", conform: ["id": UUID.self])
+    @GET("/user/\(#p("id", UUID.self))")
     @Sendable func user(request: Request, context: Context) async throws -> Response {
         return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(
             string: "User {id} = \(context.parameters.get("id", as: String.self) ?? "nil")"
         )))
     }
 
-    // Mixed typed parameters, plus an untyped one that defaults to String.
-    @GET("/org/{orgId}/user/{userId}/tag/{tag}", conform: ["orgId": UUID.self, "userId": Int.self])
+    // Mixed typed parameters, plus an untyped ({tag}) one that defaults to String.
+    @GET("/org/\(#p("orgId", UUID.self))/user/\(#p("userId", Int.self))/tag/{tag}")
     @Sendable func orgUser(request: Request, context: Context) async throws -> Response {
         return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(
             string: "OrgUser = "
@@ -88,10 +88,26 @@ struct PathArgumentsMacroRoutingController {
     }
 
     // A project-defined CustomStringConvertible type.
-    @GET("/post/{slug}", conform: ["slug": Slug.self])
+    @GET("/post/\(#p("slug", Slug.self))")
     @Sendable func post(request: Request, context: Context) async throws -> Response {
         return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(
             string: "Post {slug} = \(context.parameters.get("slug", as: String.self) ?? "nil")"
         )))
+    }
+
+    // The remaining spellings of the parameter macro — all resolve to the same ParamMacro.
+    @GET("/alias/param/\(#param("id", UUID.self))")
+    @Sendable func aliasParam(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "aliasParam")))
+    }
+
+    @GET("/alias/hb/\(#hbParam("id", UUID.self))")
+    @Sendable func aliasHbParam(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "aliasHbParam")))
+    }
+
+    @GET("/alias/explicit/\(#HummingbirdMacroRoutingParam("id", UUID.self))")
+    @Sendable func aliasExplicitParam(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "aliasExplicitParam")))
     }
 }

--- a/Tests/Sources/PathAgumentsMacroRoutingController.swift
+++ b/Tests/Sources/PathAgumentsMacroRoutingController.swift
@@ -110,4 +110,28 @@ struct PathArgumentsMacroRoutingController {
     @Sendable func aliasExplicitParam(request: Request, context: Context) async throws -> Response {
         return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "aliasExplicitParam")))
     }
+
+    // Partial / prefix-capture: {id}.jpg (a literal suffix after the parameter).
+    @GET("/img/\(#p("id", UUID.self)).jpg")
+    @Sendable func image(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "image")))
+    }
+
+    // Suffix-capture: a literal prefix before the parameter, file{ext}.
+    @GET("/download/file\(#p("ext", String.self))")
+    @Sendable func download(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "download")))
+    }
+
+    // A reserved word as the parameter name — must be backticked in the generated body.
+    @GET("/kw/\(#p("default", String.self))")
+    @Sendable func keyword(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "keyword")))
+    }
+
+    // A repeated parameter collapses into a single path(id:) argument filling both positions.
+    @GET("/repeat/\(#p("id", UUID.self))/again/\(#p("id", UUID.self))")
+    @Sendable func repeatedParam(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "repeated")))
+    }
 }

--- a/Tests/TestPathArguments.swift
+++ b/Tests/TestPathArguments.swift
@@ -102,4 +102,11 @@ struct MacroRoutingTestPathArguments {
         )
     }
 
+    @Test("Loose Parameter Names")
+    func testLooseNames() {
+        // Names Hummingbird allows but that aren't plain identifiers work via raw (backticked) labels.
+        #expect(Controller.$Routing.spacedName.path(`user id`: "abc") == "/space/abc")
+        #expect(Controller.$Routing.dashedName.path(`user-id`: "abc") == "/dash/abc")
+    }
+
 }

--- a/Tests/TestPathArguments.swift
+++ b/Tests/TestPathArguments.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 import Hummingbird
 import HummingbirdMacroRouting
@@ -46,9 +47,29 @@ struct MacroRoutingTestPathArguments {
         #expect(
             Controller.$Routing.mixed.path(
                 one: "apple", two: "banana", three: "carrot",
-                four: "durian", five: "eggplant" 
+                four: "durian", five: "eggplant"
             ) == "/mixed/apple/banana/carrot/durian/eggplant"
         )
     }
-    
+
+    @Test("Typed Parameters")
+    func testTypedParameters() {
+        // Single UUID parameter — interpolation matches .uuidString.
+        let id = UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!
+        #expect(
+            Controller.$Routing.user.path(id: id) == "/user/E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
+        )
+
+        // Mixed types: UUID + Int, with an untyped (String) parameter defaulting through.
+        #expect(
+            Controller.$Routing.orgUser.path(orgId: id, userId: 42, tag: "featured")
+                == "/org/E621E1F8-C36C-495A-93FC-0C247A3E6E5F/user/42/tag/featured"
+        )
+
+        // Project-defined CustomStringConvertible type.
+        #expect(
+            Controller.$Routing.post.path(slug: Slug(value: "Hello-World")) == "/post/hello-world"
+        )
+    }
+
 }

--- a/Tests/TestPathArguments.swift
+++ b/Tests/TestPathArguments.swift
@@ -72,4 +72,13 @@ struct MacroRoutingTestPathArguments {
         )
     }
 
+    @Test("Parameter Macro Aliases")
+    func testParameterMacroAliases() {
+        // All four spellings resolve to the same ParamMacro and produce a typed path(id: UUID).
+        let id = UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!
+        #expect(Controller.$Routing.aliasParam.path(id: id) == "/alias/param/E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
+        #expect(Controller.$Routing.aliasHbParam.path(id: id) == "/alias/hb/E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
+        #expect(Controller.$Routing.aliasExplicitParam.path(id: id) == "/alias/explicit/E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
+    }
+
 }

--- a/Tests/TestPathArguments.swift
+++ b/Tests/TestPathArguments.swift
@@ -81,4 +81,25 @@ struct MacroRoutingTestPathArguments {
         #expect(Controller.$Routing.aliasExplicitParam.path(id: id) == "/alias/explicit/E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
     }
 
+    @Test("Partial and Suffix Captures")
+    func testPartialCaptures() {
+        let id = UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!
+        // prefix-capture {id}.jpg — literal suffix preserved.
+        #expect(Controller.$Routing.image.path(id: id) == "/img/E621E1F8-C36C-495A-93FC-0C247A3E6E5F.jpg")
+        // suffix-capture file{ext} — literal prefix preserved.
+        #expect(Controller.$Routing.download.path(ext: ".json") == "/download/file.json")
+        // reserved-word parameter name, backticked in the generated body.
+        #expect(Controller.$Routing.keyword.path(default: "x") == "/kw/x")
+    }
+
+    @Test("Repeated Parameter Collapses")
+    func testRepeatedParameter() {
+        // One `id:` argument fills every occurrence in the path.
+        let id = UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!
+        #expect(
+            Controller.$Routing.repeatedParam.path(id: id)
+                == "/repeat/E621E1F8-C36C-495A-93FC-0C247A3E6E5F/again/E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
+        )
+    }
+
 }


### PR DESCRIPTION
Now uses a freestanding macro to denote typed parameters. Hummingbird sees these in the normal way, but the additional types enforced by the compiler here (before our macro expands) gives us type safety on parameters and in `path(…)`.