### PR TITLE
controller extensions

### DIFF
--- a/MacroExpansionTests/RoutingExtensionMacroTests.swift
+++ b/MacroExpansionTests/RoutingExtensionMacroTests.swift
@@ -1,0 +1,223 @@
+import XCTest
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+
+// The macro implementations live in the RoutingMacros plugin module.
+@testable import RoutingMacros
+
+// NOTE: this uses XCTest rather than Swift Testing on purpose. `assertMacroExpansion`
+// reports failures via XCTest's failure handler; under Swift Testing there is no
+// XCTest context, so its assertions are silently dropped and every test "passes".
+
+private nonisolated(unsafe) let testMacros: [String: Macro.Type] = [
+    "MacroRouting": RoutingMacro.self,
+    "MacroRoutingExtension": RoutingExtensionMacro.self,
+    "GET": GETMacro.self,
+    "POST": POSTMacro.self,
+]
+
+final class RoutingExtensionMacroTests: XCTestCase {
+
+    /// Declaring `extensions: ["admin"]` on the base must add exactly three things
+    /// to the base expansion: the `addRoutes($adminRoutes)` merge inside `$routes`,
+    /// the `+ C.$admin.$all` / `typealias $admin` surface inside `$Routing`, and the
+    /// `$admin_is_listed_in_MacroRouting_extensions` marker.
+    func testBaseWithExtensionNamespace() {
+        assertMacroExpansion(
+            """
+            @MacroRouting(extensions: ["admin"])
+            struct C {
+                @GET("/main")
+                func getMain() {}
+            }
+            """,
+            expandedSource: """
+            struct C {
+                func getMain() {}
+            }
+
+            extension C {
+                    var $routes: RouteCollectionContainer<Context> {
+                    let routes = RouteCollection(context: Context.self)
+                    _ = routes.on(
+                            "/main",
+                            method: .get,
+                            use: `getMain`
+                        )
+                    routes.addRoutes($adminRoutes)
+                    return RouteCollectionContainer(routeCollection: routes)
+                }
+                    struct $Routing {
+                            private init() {
+                    }
+                            static let $all: [any MacroRoutingRoute.Type] = [
+                                `getMain`.self
+                            ] + C.$$admin.$all
+                            static let $prefix: String? = nil
+                    struct `getMain`: MacroRoutingRoute {
+                            private init() {
+                    }
+                            static let method: HTTPRequest.Method = .get
+                            static let handler: String = "getMain"
+                            static let name: String = "getMain"
+                            static let prefixedPath: String = "/main"
+                            static let rawPath: String = "/main"
+                    static let path: String = "/main"
+                    }
+                    typealias $admin = C.$$admin
+                    }
+                    enum $admin_is_listed_in_MacroRouting_extensions {
+                    }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    /// `@MacroRoutingExtension("admin")` on an extension must emit the namespaced
+    /// routes property, the namespaced route-struct container, and the typealias
+    /// that references the base's declaration marker.
+    func testExtensionExpansion() {
+        assertMacroExpansion(
+            """
+            @MacroRoutingExtension("admin")
+            extension C {
+                @POST("/extension")
+                func logOutHandler() {}
+            }
+            """,
+            expandedSource: """
+            extension C {
+                func logOutHandler() {}
+
+                var $adminRoutes: RouteCollectionContainer<Context> {
+                        let routes = RouteCollection(context: Context.self)
+                        _ = routes.on(
+                                "/extension",
+                                method: .post,
+                                use: `logOutHandler`
+                            )
+                        return RouteCollectionContainer(routeCollection: routes)
+                    }
+
+                struct $$admin {
+                        private init() {
+                        }
+                        static let $all: [any MacroRoutingRoute.Type] = [
+                            `logOutHandler`.self
+                        ]
+                        static let $prefix: String? = nil
+                        struct `logOutHandler`: MacroRoutingRoute {
+                                private init() {
+                        }
+                                static let method: HTTPRequest.Method = .post
+                                static let handler: String = "logOutHandler"
+                                static let name: String = "logOutHandler"
+                                static let prefixedPath: String = "/extension"
+                                static let rawPath: String = "/extension"
+                        static let path: String = "/extension"
+                        }
+                }
+
+                private typealias $MacroRoutingDeclared_admin = $admin_is_listed_in_MacroRouting_extensions
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    /// A reserved namespace ("routes"/"Routing" would collide with the base's own
+    /// generated members) must be diagnosed and dropped from codegen.
+    func testReservedNamespaceIsDiagnosed() {
+        assertMacroExpansion(
+            """
+            @MacroRouting(extensions: ["routes"])
+            struct C {
+            }
+            """,
+            expandedSource: """
+            struct C {
+            }
+
+            extension C {
+                    var $routes: RouteCollectionContainer<Context> {
+                    let routes = RouteCollection(context: Context.self)
+                    return RouteCollectionContainer(routeCollection: routes)
+                }
+                    struct $Routing {
+                            private init() {
+                    }
+                            static let $all: [any MacroRoutingRoute.Type] = [
+
+                            ]
+                            static let $prefix: String? = nil
+                    }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "Extension namespace 'routes' is reserved", line: 1, column: 28)
+            ],
+            macros: testMacros
+        )
+    }
+
+    /// A namespace that isn't a valid Swift identifier must be diagnosed and
+    /// dropped; valid ones on either side of it survive.
+    func testInvalidAndDuplicateNamespacesAreDiagnosed() {
+        assertMacroExpansion(
+            """
+            @MacroRouting(extensions: ["ok", "not ok", "ok"])
+            struct C {
+            }
+            """,
+            expandedSource: """
+            struct C {
+            }
+
+            extension C {
+                    var $routes: RouteCollectionContainer<Context> {
+                    let routes = RouteCollection(context: Context.self)
+                    routes.addRoutes($okRoutes)
+                    return RouteCollectionContainer(routeCollection: routes)
+                }
+                    struct $Routing {
+                            private init() {
+                    }
+                            static let $all: [any MacroRoutingRoute.Type] = [
+
+                            ] + C.$$ok.$all
+                            static let $prefix: String? = nil
+                    typealias $ok = C.$$ok
+                    }
+                    enum $ok_is_listed_in_MacroRouting_extensions {
+                    }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "Extension namespace 'not ok' must be a valid Swift identifier", line: 1, column: 34),
+                DiagnosticSpec(message: "Extension namespace 'ok' is already declared", line: 1, column: 44),
+            ],
+            macros: testMacros
+        )
+    }
+
+    /// @MacroRoutingExtension attached to anything but an extension must be
+    /// diagnosed and emit nothing.
+    func testExtensionMacroOnStructIsDiagnosed() {
+        assertMacroExpansion(
+            """
+            @MacroRoutingExtension("admin")
+            struct C {
+            }
+            """,
+            expandedSource: """
+            struct C {
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "@MacroRoutingExtension can only be attached to an extension", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+    }
+}

--- a/README.md
+++ b/README.md
@@ -198,6 +198,56 @@ The argument names are synthesized by MacroRouting, so they're available to well
 
 ![IDE completion of `ApiController.$Routing.logs.path`](https://files.scoat.es/IKYWGNmUCq.gif)
 
+## Controller Extensions
+
+Swift doesn't allow extension macros (like `@MacroRouting`, which has the `extension` macro role from [SE-0402](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0402-extension-macros.md)) to be attached to an `extension`, and macro expansions can't see across declarations. So routes declared in an extension of a controller use a companion macro, `@MacroRoutingExtension`, with a *namespace* that you declare once on the base controller:
+
+```swift
+@MacroRouting(extensions: ["admin"])
+struct UserController {
+    typealias Context = AppRequestContext
+
+    @GET("/main")
+    @Sendable func getMain(request: Request, context: Context) async throws -> Response {
+        …
+    }
+}
+
+@MacroRoutingExtension("admin")
+extension UserController {
+    @POST("/logout")
+    @Sendable func logOutHandler(request: Request, context: Context) async throws -> Response {
+        …
+    }
+}
+```
+
+Wiring is unchanged — one call, and the extension's routes are included automatically:
+
+```swift
+router.addRoutes(UserController().$routes)
+```
+
+Static route lookup works for extension routes too, namespaced under `$Routing`:
+
+```swift
+UserController.$Routing.getMain.path              // "/main"
+UserController.$Routing.$admin.logOutHandler.path // "/logout"
+UserController.$Routing.$all                      // complete: base + extension routes
+```
+
+You can declare as many namespaces (and matching extensions) as you like. Both directions are checked at compile time:
+
+- Declaring `extensions: ["admin"]` without a matching `@MacroRoutingExtension("admin")` fails with `type 'UserController' has no member '$adminRoutes'`.
+- Writing `@MacroRoutingExtension("admin")` without declaring `"admin"` on the base fails with `cannot find type '$admin_is_listed_in_MacroRouting_extensions' in scope`.
+
+So a forgotten declaration can never silently drop routes.
+
+Notes:
+
+- Namespaces must be valid Swift identifiers; `routes` and `Routing` are reserved.
+- The base `prefix:` does **not** cascade into extensions (each expansion is sandboxed, and static `path` values must match runtime paths). Extensions take their own prefix: `@MacroRoutingExtension("admin", prefix: "/admin")`.
+
 ## Tests
 
 There's some useful reference code available in the [test suite](https://github.com/sloatescoan/hummingbird-macrorouting/tree/main/Tests).

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ struct UserController {
     }
 }
 
+// this extension might be in a different file
 @MacroRoutingExtension("admin")
 extension UserController {
     @POST("/logout")

--- a/Sources/HummingbirdMacroRouting/attachment.swift
+++ b/Sources/HummingbirdMacroRouting/attachment.swift
@@ -1,5 +1,13 @@
 @attached(extension, names: arbitrary)
-public macro MacroRouting(prefix: String? = nil) = #externalMacro(module: "RoutingMacros", type: "RoutingMacro")
+public macro MacroRouting(prefix: String? = nil, extensions: [String] = []) = #externalMacro(module: "RoutingMacros", type: "RoutingMacro")
+
+// Extension-role macros can't be attached to an `extension`, so routes declared in
+// extensions of a controller use this member-role macro instead. Each extension gets
+// a namespace, declared once on the base: @MacroRouting(extensions: ["admin"]).
+// The base then wires `$adminRoutes` into `$routes` and exposes the extension's
+// route structs as `$Routing.$admin` — both directions are compile-checked.
+@attached(member, names: arbitrary)
+public macro MacroRoutingExtension(_ namespace: String, prefix: String? = nil) = #externalMacro(module: "RoutingMacros", type: "RoutingExtensionMacro")
 
 @attached(peer, names: arbitrary)
 public macro GET(_ path: String, name: String? = nil) = #externalMacro(module: "RoutingMacros", type: "GETMacro")

--- a/Sources/RoutingMacros/DiagnosticMessages.swift
+++ b/Sources/RoutingMacros/DiagnosticMessages.swift
@@ -23,3 +23,42 @@ struct MsgNameError: DiagnosticMessage {
         self.message = "The name associated with this route ('\(name)') must be a valid Swift identifier"
     }
 }
+
+struct MsgExtensionOnly: DiagnosticMessage {
+    let diagnosticID = MessageID(domain: "MacroRouting", id: "extensionOnly")
+    let severity: DiagnosticSeverity = .error
+    let message = "@MacroRoutingExtension can only be attached to an extension"
+}
+
+struct MsgNamespaceMissing: DiagnosticMessage {
+    let diagnosticID = MessageID(domain: "MacroRouting", id: "namespaceMissing")
+    let severity: DiagnosticSeverity = .error
+    let message = "@MacroRoutingExtension requires a namespace as a string literal"
+}
+
+struct MsgNamespaceError: DiagnosticMessage {
+    let diagnosticID = MessageID(domain: "MacroRouting", id: "namespaceError")
+    let severity: DiagnosticSeverity = .error
+    let message: String
+    init(name: String) {
+        self.message = "Extension namespace '\(name)' must be a valid Swift identifier"
+    }
+}
+
+struct MsgNamespaceReserved: DiagnosticMessage {
+    let diagnosticID = MessageID(domain: "MacroRouting", id: "namespaceReserved")
+    let severity: DiagnosticSeverity = .error
+    let message: String
+    init(name: String) {
+        self.message = "Extension namespace '\(name)' is reserved"
+    }
+}
+
+struct MsgNamespaceConflict: DiagnosticMessage {
+    let diagnosticID = MessageID(domain: "MacroRouting", id: "namespaceConflict")
+    let severity: DiagnosticSeverity = .error
+    let message: String
+    init(name: String) {
+        self.message = "Extension namespace '\(name)' is already declared"
+    }
+}

--- a/Sources/RoutingMacros/RoutingMacros.swift
+++ b/Sources/RoutingMacros/RoutingMacros.swift
@@ -14,11 +14,28 @@ struct RoutingMacros: CompilerPlugin {
         HEADMacro.self,
         PATCHMacro.self,
         RoutingMacro.self,
+        RoutingExtensionMacro.self,
     ]
 }
 enum Method: String, CaseIterable {
     case get, post, put, delete, head, patch
     static var allValues: [String] { Self.allCases.map { "\($0)".uppercased() } }
+}
+
+/// Valid Swift identifier: used for route names and extension namespaces.
+let identifierPattern = #"^[A-Za-z_][A-Za-z0-9_]*$"#
+
+/// Namespaces that would generate members colliding with the base macro's own
+/// output (`$routes`, `$Routing`).
+let reservedNamespaces: Set<String> = ["routes", "Routing"]
+
+/// The actual name of the route-struct container a `@MacroRoutingExtension`
+/// namespace generates. It's deliberately not `$<namespace>` — that name is
+/// reserved for the `typealias` inside `$Routing`, so `Controller.$Routing.$admin`
+/// is the documented spelling; `Controller.$admin` doesn't exist (`Controller.$$admin`
+/// does, but isn't advertised).
+private func internalContainerName(_ namespace: String) -> String {
+    "$$\(namespace)"
 }
 
 struct CapturedRoute {
@@ -57,6 +74,246 @@ private func reconstructedLiteral(_ literal: StringLiteralExprSyntax) -> String 
     literal.segments.map { $0.description }.joined()
 }
 
+/// Scan a member block for functions carrying @GET/@POST/… attributes and
+/// capture their routes. Shared by `RoutingMacro` (struct body) and
+/// `RoutingExtensionMacro` (extension body).
+private func captureRoutes(
+    in members: MemberBlockItemListSyntax,
+    context: some MacroExpansionContext
+) -> [CapturedRoute] {
+    return members.flatMap { member -> [CapturedRoute] in
+        guard let function = member.decl.as(FunctionDeclSyntax.self) else { return [] }
+
+        // Find all HTTP method attributes (@GET, @POST, etc.)
+        let httpAttributes = function.attributes.compactMap { attr in
+            attr.as(AttributeSyntax.self)
+        }.filter { attr in
+            let attrName = attr.attributeName.as(IdentifierTypeSyntax.self)?.name.text ?? ""
+            return Method.allValues.contains(attrName)
+        }
+
+        // this second compactMap is because we might have multiple @VERB attachments for one function
+        return httpAttributes.compactMap { httpAttribute in
+            // Extract method, path, and name for each attribute
+            guard
+                let arguments = httpAttribute.arguments?.as(LabeledExprListSyntax.self),
+                let firstArg = arguments.first?.expression.as(StringLiteralExprSyntax.self),
+                let methodName = httpAttribute.attributeName.as(IdentifierTypeSyntax.self)?.name.text,
+                let method = Method(rawValue: methodName.lowercased())
+            else {
+                context.diagnose(
+                    Diagnostic(
+                        node: member.decl,
+                        message: MsgMalformed()
+                    )
+                )
+                return nil
+            }
+
+            // Preserve any `\(…)` interpolation in the path so it passes
+            // through to the generated code instead of truncating.
+            let path = reconstructedLiteral(firstArg)
+
+            // Extract the route name
+            let name: String
+            if
+                let nameExpr = arguments.first(where: { $0.label?.text == "name" })?.expression.as(StringLiteralExprSyntax.self)
+            {
+                // Reconstruct fully: an interpolated name isn't a valid
+                // identifier, so it should fail the check below rather than
+                // be truncated to a passing prefix.
+                let nameValue = reconstructedLiteral(nameExpr)
+                let isValid = nameValue.range(of: identifierPattern, options: .regularExpression) != nil
+                guard isValid else {
+                    context.diagnose(
+                        Diagnostic(
+                            node: member.decl,
+                            message: MsgNameError(name: nameValue)
+                        )
+                    )
+                    return nil
+                }
+                name = nameValue
+            } else {
+                name = function.name.text
+            }
+
+
+            return CapturedRoute(method: method, path: path, handler: function.name.text, name: name, function: function)
+        }
+    }
+}
+
+/// Make sure we don't have more than one route with the same name.
+/// Diagnose each collision *and* drop the duplicate from codegen (first
+/// occurrence wins) — otherwise we'd emit two `struct <name>` declarations
+/// and the compiler would pile an "invalid redeclaration" error, pointing
+/// into generated code, on top of our clear diagnostic.
+private func dedupeRoutes(
+    _ routes: [CapturedRoute],
+    context: some MacroExpansionContext
+) -> [CapturedRoute] {
+    var routeNames: Set<String> = []
+    var uniqueRoutes: [CapturedRoute] = []
+    for route in routes {
+        if routeNames.contains(route.name) {
+            context.diagnose(
+                Diagnostic(
+                    node: route.function,
+                    message: MsgNameConflict(name: route.name)
+                )
+            )
+        } else {
+            routeNames.insert(route.name)
+            uniqueRoutes.append(route)
+        }
+    }
+    return uniqueRoutes
+}
+
+/// Generate the routes computed property (`$routes` for the base macro,
+/// `$<namespace>Routes` for extensions). For the base, each declared extension
+/// namespace's collection is merged in — the reference to `$<ns>Routes` doubles
+/// as the compile-time check that the matching @MacroRoutingExtension exists.
+private func routesVarCode(
+    varName: String,
+    routes: [CapturedRoute],
+    prefix: String?,
+    extensionNamespaces: [String]
+) -> String {
+    // this is kind of ugly, but it works…
+    var code = """
+        var \(varName): RouteCollectionContainer<Context> {
+            let routes = RouteCollection(context: Context.self)
+    """
+    for route in routes {
+        code += """
+            _ = routes.on(
+                "\(prefix ?? "")\(route.path)",
+                method: .\(route.method.rawValue.lowercased()),
+                use: `\(route.handler)`
+            )
+        """
+    }
+    for namespace in extensionNamespaces {
+        code += """
+            routes.addRoutes($\(namespace)Routes)
+        """
+    }
+    code += """
+            return RouteCollectionContainer(routeCollection: routes)
+        }
+    """
+    return code
+}
+
+/// Generate the route-struct container (`$Routing` for the base macro,
+/// `$<namespace>` for extensions). For the base, each declared extension
+/// namespace contributes to `$all` and gets a `typealias $<ns>` so extension
+/// routes are reachable as `<Type>.$Routing.$<ns>.<route>`.
+private func routingContainerCode(
+    containerName: String,
+    typeName: String,
+    routes: [CapturedRoute],
+    prefix: String?,
+    extensionNamespaces: [String]
+) -> String {
+    let allSuffix = extensionNamespaces.map({ " + \(typeName).\(internalContainerName($0)).$all" }).joined()
+    var code = """
+        struct \(containerName) {
+            private init() {}
+            static let $all: [any MacroRoutingRoute.Type] = [
+                \(routes.map({ "`" + $0.name + "`" + ".self" }).joined(separator: ", "))
+            ]\(allSuffix)
+            static let $prefix: String? = \(prefix == nil ? "nil" : "\"\(prefix!)\"")
+    """
+
+    for route in routes {
+        var captured: [String] = []
+        var out: [String] = []
+
+        let prefixedPath = "\(prefix ?? "")\(route.path)"
+
+        for component in prefixedPath.split(separator: "/") {
+            if component.first == "{" {
+                let name = String(component.dropFirst().dropLast())
+                captured.append(name)
+                out.append("\\(`" + name + "`)")
+            } else if component.first == ":" {
+                let name = String(component.dropFirst())
+                captured.append(name)
+                out.append("\\(`" + name + "`)")
+            } else {
+                // there are other types like wildcards, but those are harder to replace
+                out.append(component.description)
+            }
+        }
+
+        code += """
+            struct `\(route.name)`: MacroRoutingRoute {
+                private init() {}
+                static let method: HTTPRequest.Method = .\(route.method.rawValue.lowercased())
+                static let handler: String = "\(route.handler)"
+                static let name: String = "\(route.name)"
+                static let prefixedPath: String = "\(prefixedPath)"
+                static let rawPath: String = "\(route.path)"
+        """
+
+        if captured.count > 0 {
+            // for routes that have captured arguments, provide path(…) (formerly resolvedPath(…))
+            code += """
+                @available(*, deprecated, renamed: "path", message: "resolvedPath(…) has been renamed to path(…)")
+                static func resolvedPath(\(captured.map({ "\($0): String"}).joined(separator: ", "))) -> String {
+                    path(\(captured.map({
+                        ReservedWord(rawValue: $0) == nil ?
+                            "\($0): \($0)"
+                            :
+                            "`\($0)`: `\($0)`"
+                    }).joined(separator: ", ")))
+                }
+                static func path(\(captured.map({ "\($0): String"}).joined(separator: ", "))) -> String {
+                    "/\(out.joined(separator: "/"))"
+                }
+            """
+        } else {
+            // this is for routes *without* captured arguments
+            code += """
+                static let path: String = "\(prefixedPath)"
+            """
+        }
+
+        code += """
+            }
+        """
+    }
+
+    for namespace in extensionNamespaces {
+        code += """
+            typealias $\(namespace) = \(typeName).\(internalContainerName(namespace))
+        """
+    }
+
+    code += """
+        }
+    """ // end container struct
+
+    return code
+}
+
+/// Extract an optional string-literal argument by label (e.g. `prefix:`).
+private func stringArgument(
+    labelled label: String,
+    in arguments: LabeledExprListSyntax?
+) -> String? {
+    guard
+        let argument = arguments?.first(where: { $0.label?.text == label }),
+        let stringLiteral = argument.expression.as(StringLiteralExprSyntax.self)
+    else {
+        return nil
+    }
+    return reconstructedLiteral(stringLiteral)
+}
+
 public struct RoutingMacro: ExtensionMacro {
     public static func expansion(
         of node: SwiftSyntax.AttributeSyntax,
@@ -69,190 +326,73 @@ public struct RoutingMacro: ExtensionMacro {
             return []
         }
 
-        let prefix: String?
-        if let prefixArg = node.arguments?.as(LabeledExprListSyntax.self)?.first {
-            if let stringLiteral = prefixArg.expression.as(StringLiteralExprSyntax.self) {
-                prefix = reconstructedLiteral(stringLiteral)
-            } else {
-                prefix = nil
-            }
-        } else {
-            prefix = nil
-        }
+        let arguments = node.arguments?.as(LabeledExprListSyntax.self)
+        let prefix = stringArgument(labelled: "prefix", in: arguments)
 
-        let routes: [CapturedRoute] = structDecl.memberBlock.members.flatMap { member -> [CapturedRoute] in
-            guard let function = member.decl.as(FunctionDeclSyntax.self) else { return [] }
-
-            // Find all HTTP method attributes (@GET, @POST, etc.)
-            let httpAttributes = function.attributes.compactMap { attr in
-                attr.as(AttributeSyntax.self)
-            }.filter { attr in
-                let attrName = attr.attributeName.as(IdentifierTypeSyntax.self)?.name.text ?? ""
-                return Method.allValues.contains(attrName)
-            }
-
-            // this second compactMap is because we might have multiple @VERB attachments for one function
-            return httpAttributes.compactMap { httpAttribute in
-                // Extract method, path, and name for each attribute
-                guard
-                    let arguments = httpAttribute.arguments?.as(LabeledExprListSyntax.self),
-                    let firstArg = arguments.first?.expression.as(StringLiteralExprSyntax.self),
-                    let methodName = httpAttribute.attributeName.as(IdentifierTypeSyntax.self)?.name.text,
-                    let method = Method(rawValue: methodName.lowercased())
-                else {
+        // extension namespaces, declared once here on the base: validated,
+        // reserved names rejected, duplicates dropped (first occurrence wins)
+        var extensionNamespaces: [String] = []
+        if
+            let extensionsArg = arguments?.first(where: { $0.label?.text == "extensions" }),
+            let arrayExpr = extensionsArg.expression.as(ArrayExprSyntax.self)
+        {
+            for element in arrayExpr.elements {
+                guard let stringLiteral = element.expression.as(StringLiteralExprSyntax.self) else {
                     context.diagnose(
-                        Diagnostic(
-                            node: member.decl,
-                            message: MsgMalformed()
-                        )
+                        Diagnostic(node: element, message: MsgNamespaceError(name: element.expression.description))
                     )
-                    return nil
+                    continue
                 }
-
-                // Preserve any `\(…)` interpolation in the path so it passes
-                // through to the generated code instead of truncating.
-                let path = reconstructedLiteral(firstArg)
-
-                // Extract the route name
-                let name: String
-                if
-                    let nameExpr = arguments.first(where: { $0.label?.text == "name" })?.expression.as(StringLiteralExprSyntax.self)
-                {
-                    // Reconstruct fully: an interpolated name isn't a valid
-                    // identifier, so it should fail the check below rather than
-                    // be truncated to a passing prefix.
-                    let nameValue = reconstructedLiteral(nameExpr)
-                    let isValid = nameValue.range(of: #"^[A-Za-z_][A-Za-z0-9_]*$"#, options: .regularExpression) != nil
-                    guard isValid else {
-                        context.diagnose(
-                            Diagnostic(
-                                node: member.decl,
-                                message: MsgNameError(name: nameValue)
-                            )
-                        )
-                        return nil
-                    }
-                    name = nameValue
-                } else {
-                    name = function.name.text
-                }
-
-
-                return CapturedRoute(method: method, path: path, handler: function.name.text, name: name, function: function)
-            }
-        }
-
-        // make sure we don't have more than one route with the same name.
-        // Diagnose each collision *and* drop the duplicate from codegen (first
-        // occurrence wins) — otherwise we'd emit two `struct <name>` declarations
-        // and the compiler would pile an "invalid redeclaration" error, pointing
-        // into generated code, on top of our clear diagnostic.
-        var routeNames: Set<String> = []
-        var uniqueRoutes: [CapturedRoute] = []
-        for route in routes {
-            if routeNames.contains(route.name) {
-                context.diagnose(
-                    Diagnostic(
-                        node: route.function,
-                        message: MsgNameConflict(name: route.name)
+                let namespace = reconstructedLiteral(stringLiteral)
+                guard namespace.range(of: identifierPattern, options: .regularExpression) != nil else {
+                    context.diagnose(
+                        Diagnostic(node: element, message: MsgNamespaceError(name: namespace))
                     )
-                )
-            } else {
-                routeNames.insert(route.name)
-                uniqueRoutes.append(route)
-            }
-        }
-
-        // this is kind of ugly, but it works…
-        var code = """
-            var $routes: RouteCollectionContainer<Context> {
-                let routes = RouteCollection(context: Context.self)
-        """
-        for route in uniqueRoutes {
-            code += """
-                _ = routes.on(
-                    "\(prefix ?? "")\(route.path)",
-                    method: .\(route.method.rawValue.lowercased()),
-                    use: `\(route.handler)`
-                )
-            """
-        }
-        code += """
-                return RouteCollectionContainer(routeCollection: routes)
-            }
-        """
-
-        code += """
-            struct $Routing {
-                private init() {}
-                static let $all: [any MacroRoutingRoute.Type] = [
-                    \(uniqueRoutes.map({ "`" + $0.name + "`" + ".self" }).joined(separator: ", "))
-                ]
-                static let $prefix: String? = \(prefix == nil ? "nil" : "\"\(prefix!)\"")
-        """
-
-        for route in uniqueRoutes {
-            var captured: [String] = []
-            var out: [String] = []
-
-            let prefixedPath = "\(prefix ?? "")\(route.path)"
-
-            for component in prefixedPath.split(separator: "/") {
-                if component.first == "{" {
-                    let name = String(component.dropFirst().dropLast())
-                    captured.append(name)
-                    out.append("\\(`" + name + "`)")
-                } else if component.first == ":" {
-                    let name = String(component.dropFirst())
-                    captured.append(name)
-                    out.append("\\(`" + name + "`)")
-                } else {
-                    // there are other types like wildcards, but those are harder to replace
-                    out.append(component.description)
+                    continue
                 }
-            }
-
-            code += """
-                struct `\(route.name)`: MacroRoutingRoute {
-                    private init() {}
-                    static let method: HTTPRequest.Method = .\(route.method.rawValue.lowercased())
-                    static let handler: String = "\(route.handler)"
-                    static let name: String = "\(route.name)"
-                    static let prefixedPath: String = "\(prefixedPath)"
-                    static let rawPath: String = "\(route.path)"
-            """
-
-            if captured.count > 0 {
-                // for routes that have captured arguments, provide path(…) (formerly resolvedPath(…))
-                code += """
-                    @available(*, deprecated, renamed: "path", message: "resolvedPath(…) has been renamed to path(…)")
-                    static func resolvedPath(\(captured.map({ "\($0): String"}).joined(separator: ", "))) -> String {
-                        path(\(captured.map({
-                            ReservedWord(rawValue: $0) == nil ?
-                                "\($0): \($0)"
-                                :
-                                "`\($0)`: `\($0)`"
-                        }).joined(separator: ", ")))
-                    }
-                    static func path(\(captured.map({ "\($0): String"}).joined(separator: ", "))) -> String {
-                        "/\(out.joined(separator: "/"))"
-                    }
-                """
-            } else {
-                // this is for routes *without* captured arguments
-                code += """
-                    static let path: String = "\(prefixedPath)"
-                """
-            }
-
-            code += """
+                guard !reservedNamespaces.contains(namespace) else {
+                    context.diagnose(
+                        Diagnostic(node: element, message: MsgNamespaceReserved(name: namespace))
+                    )
+                    continue
                 }
-            """
+                guard !extensionNamespaces.contains(namespace) else {
+                    context.diagnose(
+                        Diagnostic(node: element, message: MsgNamespaceConflict(name: namespace))
+                    )
+                    continue
+                }
+                extensionNamespaces.append(namespace)
+            }
         }
 
-        code += """
-            }
-        """ // end struct $Routing
+        let routes = captureRoutes(in: structDecl.memberBlock.members, context: context)
+        let uniqueRoutes = dedupeRoutes(routes, context: context)
+        let typeName = type.trimmedDescription
+
+        var code = routesVarCode(
+            varName: "$routes",
+            routes: uniqueRoutes,
+            prefix: prefix,
+            extensionNamespaces: extensionNamespaces
+        )
+        code += routingContainerCode(
+            containerName: "$Routing",
+            typeName: typeName,
+            routes: uniqueRoutes,
+            prefix: prefix,
+            extensionNamespaces: extensionNamespaces
+        )
+
+        // Marker types, one per declared namespace: the matching
+        // @MacroRoutingExtension references its marker, so an extension whose
+        // namespace was never declared here fails to compile with
+        // "cannot find type '$<ns>_is_listed_in_MacroRouting_extensions'".
+        for namespace in extensionNamespaces {
+            code += """
+                enum $\(namespace)_is_listed_in_MacroRouting_extensions {}
+            """
+        }
 
         let extensionCode = """
         extension \(type) {
@@ -264,6 +404,67 @@ public struct RoutingMacro: ExtensionMacro {
             fatalError("Failed to parse extension declaration")
         }
         return [extDecl]
+    }
+}
+
+public struct RoutingExtensionMacro: MemberMacro {
+    public static func expansion(
+        of node: SwiftSyntax.AttributeSyntax,
+        providingMembersOf declaration: some SwiftSyntax.DeclGroupSyntax,
+        conformingTo protocols: [SwiftSyntax.TypeSyntax],
+        in context: some SwiftSyntaxMacros.MacroExpansionContext
+    ) throws -> [SwiftSyntax.DeclSyntax] {
+        guard let extensionDecl = declaration.as(ExtensionDeclSyntax.self) else {
+            context.diagnose(Diagnostic(node: node, message: MsgExtensionOnly()))
+            return []
+        }
+
+        // the namespace is the required, unlabelled first argument
+        guard
+            let arguments = node.arguments?.as(LabeledExprListSyntax.self),
+            let namespaceArg = arguments.first,
+            namespaceArg.label == nil,
+            let namespaceLiteral = namespaceArg.expression.as(StringLiteralExprSyntax.self)
+        else {
+            context.diagnose(Diagnostic(node: node, message: MsgNamespaceMissing()))
+            return []
+        }
+        let namespace = reconstructedLiteral(namespaceLiteral)
+        guard namespace.range(of: identifierPattern, options: .regularExpression) != nil else {
+            context.diagnose(Diagnostic(node: node, message: MsgNamespaceError(name: namespace)))
+            return []
+        }
+        guard !reservedNamespaces.contains(namespace) else {
+            context.diagnose(Diagnostic(node: node, message: MsgNamespaceReserved(name: namespace)))
+            return []
+        }
+
+        // extensions take their own prefix; the base prefix does not cascade
+        // (it's statically unknowable from this expansion, and static `path`
+        // values must match the runtime paths)
+        let prefix = stringArgument(labelled: "prefix", in: arguments)
+
+        let routes = captureRoutes(in: extensionDecl.memberBlock.members, context: context)
+        let uniqueRoutes = dedupeRoutes(routes, context: context)
+
+        return [
+            DeclSyntax(stringLiteral: routesVarCode(
+                varName: "$\(namespace)Routes",
+                routes: uniqueRoutes,
+                prefix: prefix,
+                extensionNamespaces: []
+            )),
+            DeclSyntax(stringLiteral: routingContainerCode(
+                containerName: internalContainerName(namespace),
+                typeName: "",
+                routes: uniqueRoutes,
+                prefix: prefix,
+                extensionNamespaces: []
+            )),
+            // compile-time check that this namespace is declared on the base:
+            // @MacroRouting(extensions: ["<ns>"]) emits the referenced marker
+            DeclSyntax(stringLiteral: "private typealias $MacroRoutingDeclared_\(namespace) = $\(namespace)_is_listed_in_MacroRouting_extensions"),
+        ]
     }
 }
 

--- a/Tests/Sources/ExtensionMacroRouting.swift
+++ b/Tests/Sources/ExtensionMacroRouting.swift
@@ -1,0 +1,30 @@
+import Hummingbird
+import HummingbirdMacroRouting
+
+@MacroRouting(extensions: ["admin", "api"])
+struct ExtensionMacroRoutingController {
+    typealias Context = SimpleMacroRoutingRequestContext
+
+    @GET("/main")
+    @Sendable func getMain(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "Main")))
+    }
+}
+
+@MacroRoutingExtension("admin")
+extension ExtensionMacroRoutingController {
+    @GET("/extension/{id}")
+    @Sendable func getExtensionId(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(
+            string: "Extension item {id} = \(context.parameters.get("id", as: String.self) ?? "nil")"
+        )))
+    }
+}
+
+@MacroRoutingExtension("api")
+extension ExtensionMacroRoutingController {
+    @POST("/api")
+    @Sendable func getApi(request: Request, context: Context) async throws -> Response {
+        return .init(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "Extension logged out")))
+    }
+}

--- a/Tests/TestExtension.swift
+++ b/Tests/TestExtension.swift
@@ -1,0 +1,82 @@
+import Testing
+import Hummingbird
+import HummingbirdMacroRouting
+import HummingbirdTesting
+
+@Suite("Extension Macro Routing Tests")
+struct MacroRoutingTestExtension {
+    typealias Context = SimpleMacroRoutingRequestContext
+    typealias Controller = ExtensionMacroRoutingController
+
+    @Test("Static Structure")
+    func testStructureStatic() {
+        // base routes, untouched by the extensions
+        #expect(Controller.$Routing.getMain.method == .get)
+        #expect(Controller.$Routing.getMain.path == "/main")
+        #expect(Controller.$Routing.$prefix == nil)
+
+        // extension routes, via the $Routing typealias
+        #expect(Controller.$Routing.$admin.getExtensionId.method == .get)
+        #expect(Controller.$Routing.$admin.getExtensionId.path(id: "42") == "/extension/42")
+
+        #expect(Controller.$Routing.$api.getApi.method == .post)
+        #expect(Controller.$Routing.$api.getApi.path == "/api")
+
+        #expect(Controller.$Routing.$admin.$prefix == nil)
+        #expect(Controller.$Routing.$api.$prefix == nil)
+
+        // $all is complete across the base and both extensions
+        #expect(
+            Controller.$Routing.$all.map({ $0.prefixedPath }) == [
+                Controller.$Routing.getMain.prefixedPath,
+                Controller.$Routing.$admin.getExtensionId.prefixedPath,
+                Controller.$Routing.$api.getApi.prefixedPath,
+            ]
+        )
+    }
+
+    @Test("Instance Structure")
+    func testInSitu() async throws {
+        let controller = Controller()
+
+        #expect(type(of: controller.$routes) == RouteCollectionContainer<Context>.self)
+
+        let router = Router(context: Context.self)
+        // one call — routes from both extensions are wired in automatically
+        router.addRoutes(controller.$routes)
+        let app = Application(
+            router: router,
+            configuration: .init()
+        )
+
+        try await app.test(.router) { client in
+            try await client.execute(
+                uri: Controller.$Routing.getMain.path,
+                method: .get
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body) == "Main")
+            }
+            try await client.execute(
+                uri: Controller.$Routing.$admin.getExtensionId.path(id: "42"),
+                method: .get
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body) == "Extension item {id} = 42")
+            }
+            try await client.execute(
+                uri: Controller.$Routing.$api.getApi.path,
+                method: .get
+            ) { response in
+                #expect(response.status == .notFound)
+            }
+            try await client.execute(
+                uri: Controller.$Routing.$api.getApi.path,
+                method: .post
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body) == "Extension logged out")
+            }
+        }
+    }
+}


### PR DESCRIPTION
We need a workaround (a second macro, and a declaration of all of the extensions) for this because composability between macros is difficult-to-impossible. I think this makes sense like this now, though.